### PR TITLE
Add EN_LINKPATTERN to epanet2.h

### DIFF
--- a/build/Linux/Makefile
+++ b/build/Linux/Makefile
@@ -54,7 +54,7 @@ docdir = $(datarootdir)/doc/epanet
 
 # Compiler and flags
 CC = gcc
-CFLAGS = -g -O3 -fPIC
+CFLAGS = -g -O3 -fPIC -std=c99
 CPPFLAGS = -I $(epanetincludedir)
 LDFLAGS = -L . -Wl,-rpath,$(libdir) -lm
 

--- a/build/Linux/Makefile_Rev
+++ b/build/Linux/Makefile_Rev
@@ -57,7 +57,7 @@ docdir = $(datarootdir)/doc/epanet
 
 # Compiler and flags
 CC = gcc
-CFLAGS = -g -O3 -fPIC
+CFLAGS = -g -O3 -fPIC -std=c99
 CPPFLAGS = -I $(epanetincludedir)
 LDFLAGS = -L . -Wl,-rpath,$(libdir) -lm
 

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -84,6 +84,7 @@
 #define EN_SETTING      12
 #define EN_ENERGY       13
 #define EN_LINKQUAL     14     /* TNT */
+#define EN_LINKPATTERN  15
 
 #define EN_DURATION     0    /* Time parameters */
 #define EN_HYDSTEP      1


### PR DESCRIPTION
Won't compile without `EN_LINKQUAL` being defined in `epanet2.h`.

Also, added `-std=c99` to compiler flags in both Linux Makefiles to suppress warnings re variables being declared in for loop initialisation statements.