### PR TITLE
Building on Linux: #define DLL_EXPORT as the empty string and link to libm

### DIFF
--- a/build/CMake/CMakeLists.txt
+++ b/build/CMake/CMakeLists.txt
@@ -15,4 +15,4 @@ add_library(epanet STATIC  ../../src/epanet.c ../../src/hydraul.c ../../src/hash
 # the standalone executable
 include_directories(../../src)
 add_executable(runepanet ../../run/main.c)
-target_link_libraries (runepanet LINK_PUBLIC epanet)
+target_link_libraries (runepanet LINK_PUBLIC epanet m)

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -47,6 +47,8 @@
     #else
       #define DLLEXPORT
     #endif
+  #else
+    #define DLLEXPORT
   #endif
 #endif
 


### PR DESCRIPTION
Couldn't get `patch-2-0-13` to build on Linux.  Fixed by 

 - Ensuring that `DLL_EXPORT` is `#define`ed as the empty string on unspecified OSs (i.e. none of `WINDOWS`, `CYGWIN` or `__APPLE__` are `#define`d)
 - Ensuring libm is linked to by appending it it to the `target_link_libraries` in `CMakeLists.txt`