### PR TITLE
undone Warnflag declaration due to cl.exe incompatibilities 

### DIFF
--- a/build/Linux/Makefile
+++ b/build/Linux/Makefile
@@ -41,10 +41,13 @@ runcmdname = runepanet2.sh
 epanetincludedir = ../../include
 # Search path for sources
 epanetsrcdir = ../../src
-VPATH = $(epanetsrcdir):$(epanetincludedir)
+epanetrundir = ../../run
+VPATH = $(epanetsrcdir):$(epanetincludedir):$(epanetrundir)
 
 # Install directories
-prefix = ~
+#prefix = /usr/local # GNU standard -- requires superuser rights
+prefix =~
+#
 exec_prefix = $(prefix)
 libdir = $(exec_prefix)/lib
 bindir = $(exec_prefix)/bin
@@ -66,11 +69,11 @@ INSTALL_DATA = $(INSTALL) -m 644
 # Files for the shared object library
 epanet_objs=hash.o hydraul.o inpfile.o input1.o input2.o \
 	    input3.o mempool.o output.o quality.o report.o \
-	    rules.o smatrix.o
+	    rules.o smatrix.o epanet.o
 # Epanet header files
-epanet_heads=enumstxt.h funcs.h hash.h mempool.h text.h toolkit.h types.h vars.h
+epanet_heads=enumstxt.h funcs.h hash.h mempool.h text.h types.h vars.h
 # Epanet main program
-epanet_main=epanet
+epanet_main=main
 # Epanet main program header files
 epanet_main_heads=epanet2.h
 
@@ -78,11 +81,9 @@ epanet_main_heads=epanet2.h
 all: $(libname) $(exename)
 
 $(libname): $(epanet_objs)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -D SOL -c $(epanetsrcdir)/$(epanet_main).c
-	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $(epanet_main).o $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@  $^
 
-$(exename): $(libname) $(epanet_main_heads)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -D CLE -c $(epanetsrcdir)/$(epanet_main).c
+$(exename): $(epanet_main).o $(epanet_main_heads)
 	$(CC) $(CFLAGS) -o $@ $(epanet_main).o -l$(epanetrootname) $(LDFLAGS)
 
 $(epanet_objs): $(epanet_heads)
@@ -95,7 +96,7 @@ install:
 	$(INSTALL_PROGRAM) -D $(exename) $(bindir)/$(exename)
 	$(INSTALL_PROGRAM) -D $(libname) $(libdir)/$(libname)
 	$(INSTALL_DATA) -D $(epanetincludedir)/epanet2.h $(includedir)/epanet2.h
-	$(INSTALL_PROGRAM) -D $(runcmdname) $(bindir)/$(runcmdname)
+	$(INSTALL_PROGRAM) -D $(runcmdname) ~/$(runcmdname)
 
 .PHONY: uninstall
 uninstall:

--- a/build/Linux/runepanet.sh.template
+++ b/build/Linux/runepanet.sh.template
@@ -1,0 +1,3 @@
+#!/bin/sh
+export LD_LIBRARY_PATH=libdir:$LD_LIBRARY_PATH
+exec exename $*

--- a/build/MinGW/Makefile
+++ b/build/MinGW/Makefile
@@ -52,7 +52,7 @@ epanet_heads=enumstxt.h funcs.h hash.h mempool.h text.h types.h vars.h epanet2.h
 # Epanet main program
 epanet_main=main
 # Epanet main program header files
-epanet_main_heads=epanet2.h text.h
+epanet_main_heads=epanet2.h
 
 .PHONY: all
 all: $(libname) $(exename)

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -36,7 +36,6 @@
 // --- define DLLEXPORT
 #ifndef DLLEXPORT
   #ifdef WINDOWS
-    #define DLLDATA  __declspec(dllexport)
     #ifdef __cplusplus
       #define DLLEXPORT extern "C" __declspec(dllexport)
     #else
@@ -53,9 +52,6 @@
   #else
     #define DLLEXPORT
   #endif
-#endif
-#ifndef DLLDATA
-    #define DLLDATA
 #endif
 
 
@@ -287,7 +283,6 @@ extern "C" {
   int  DLLEXPORT ENsetcurvevalue(int index, int pnt, EN_API_FLOAT_TYPE x, EN_API_FLOAT_TYPE y);
   int  DLLEXPORT ENsetcurve(int index, EN_API_FLOAT_TYPE *x, EN_API_FLOAT_TYPE *y, int len);
   int  DLLEXPORT ENaddcurve(char *id);
-  char DLLDATA Warnflag;
   
 #if defined(__cplusplus)
 }

--- a/run/main.c
+++ b/run/main.c
@@ -1,10 +1,17 @@
 #include <stdio.h>
+#include <string.h>
 #include "epanet2.h"
-#include "text.h"
+
+/* text copied here, no more need of include "text.h" */
+#define FMT01  "\n... EPANET Version %d.%d.%d\n"
+#define FMT03  "\n Correct syntax is:\n epanet <input file> <output file>\n"
+#define FMT09  "\n... EPANET completed.\n"
+#define FMT10  "\n... EPANET completed. There are warnings."
+#define FMT11  "\n... EPANET completed. There are errors."
+
 
 void  writeConsole(char *s);
 
-extern char Warnflag;
 
 /*
 ----------------------------------------------------------------
@@ -23,40 +30,70 @@ int   main(int argc, char *argv[])
  **  Command line for stand-alone operation is:
  **    progname f1  f2  f3
  **  where progname = name of executable this code was compiled to,
- **  f1 = name of input file, f2 = name of report file, and
- **  f3 = name of binary output file (optional).
+ **  f1 = name of input file,
+ **  f2 = name of report file (optional, stdout if left blank)
+ **  f3 = name of binary output file (optional, nullfile if left blank).
  **--------------------------------------------------------------
  */
 {
   char *f1,*f2,*f3;
   char blank[] = "";
+  char errmsg[40];
   int  errcode;
+  int  version;
+  char s[25];
+
   
   /* Check for proper number of command line arguments */
-  if (argc < 3) {
+  if (argc < 2) {
     writeConsole(FMT03);
   }
   else {
     /* Call the main control function */
     f1 = argv[1];
-    f2 = argv[2];
+    if (argc > 2) {
+      f2 = argv[2];
+    }
+    else {
+      f2 = blank;
+    }
     if (argc > 3) {
       f3 = argv[3];
     }
     else {
       f3 = blank;
     }
-    writeConsole(FMT01);
-    errcode = ENepanet(f1,f2,f3,NULL);
-    if (errcode > 0) {
-      writeConsole(FMT11);
-    }
-    else if (Warnflag > 0) {
-      writeConsole(FMT10);
-    }
-    else {
-      writeConsole(FMT09);
-    }
+  }
+
+  /* get version from DLL and trasform in Major.Minor.Patch format
+  instead of hardcoded version */
+  ENgetversion(&version);
+  int major=  version/10000;
+  int minor=  (version%10000)/100;
+  int patch=  version%100;
+  sprintf(s,FMT01, major , minor, patch);
+  writeConsole(s);
+
+  if (strlen(f2)> 0) {
+     /* use stdout for progress messages */
+     errcode = ENepanet(f1,f2,f3,writeConsole);
+  }
+  else {
+     /* use stdout for reporting, no progress messages */
+     errcode = ENepanet(f1,f2,f3,NULL);
+  }
+
+  /* Error/Warning check   */
+  if (errcode == 0)   writeConsole(FMT09);
+  else {
+     if (errcode > 100) {
+        writeConsole(FMT11);
+     }
+     else {
+        writeConsole(FMT10);
+     }
+    ENgeterror(errcode, errmsg, 40);
+    writeConsole(errmsg);
   }
   return(0);
 }                                       /* End of main */
@@ -70,6 +107,8 @@ void  writeConsole(char *s)
  **----------------------------------------------------------------
  */
 {
-  fprintf(stdout,"%s",s);
+  fprintf(stdout,"%s\n",s);
   fflush(stdout);
 }
+
+

--- a/run/main.c
+++ b/run/main.c
@@ -2,12 +2,14 @@
 #include <string.h>
 #include "epanet2.h"
 
+#define   MAXMSG         79       /* Max. # characters in message text      */
+#define   MAXWARNCODE    99      
 /* text copied here, no more need of include "text.h" */
-#define FMT01  "\n... EPANET Version %d.%d.%d\n"
+#define FMT01  "\nEPANET Version %d.%d.%d\n"
 #define FMT03  "\n Correct syntax is:\n epanet <input file> <output file>\n"
-#define FMT09  "\n... EPANET completed.\n"
-#define FMT10  "\n... EPANET completed. There are warnings."
-#define FMT11  "\n... EPANET completed. There are errors."
+#define FMT09  "\nEPANET completed.\n"
+#define FMT10  "\nEPANET completed. There are warnings."
+#define FMT11  "\nEPANET completed. There are errors."
 
 
 void  writeConsole(char *s);
@@ -38,42 +40,50 @@ int   main(int argc, char *argv[])
 {
   char *f1,*f2,*f3;
   char blank[] = "";
-  char errmsg[40];
+  char errmsg[MAXMSG+1]="";
   int  errcode;
   int  version;
   char s[25];
+  int major;
+  int minor;
+  int patch;
+
+  /* get version from DLL and trasform in Major.Minor.Patch format
+  instead of hardcoded version */
+  ENgetversion(&version);
+  major=  version/10000;
+  minor=  (version%10000)/100;
+  patch=  version%100;
+  sprintf(s,FMT01, major , minor, patch);
+  writeConsole(s);
 
   
   /* Check for proper number of command line arguments */
   if (argc < 2) {
     writeConsole(FMT03);
+    return(1);
+  }
+
+  /* set inputfile name */
+  f1 = argv[1];
+  if (argc > 2) {
+    /* set rptfile name */
+    f2 = argv[2];
   }
   else {
-    /* Call the main control function */
-    f1 = argv[1];
-    if (argc > 2) {
-      f2 = argv[2];
-    }
-    else {
-      f2 = blank;
-    }
-    if (argc > 3) {
-      f3 = argv[3];
-    }
-    else {
-      f3 = blank;
-    }
+    /* use stdout for rptfile */
+    f2 = blank;
+  }
+  if (argc > 3) {
+    /* set binary output file name */
+    f3 = argv[3];
+  }
+  else {
+    /* NO binary output*/
+    f3 = blank;
   }
 
-  /* get version from DLL and trasform in Major.Minor.Patch format
-  instead of hardcoded version */
-  ENgetversion(&version);
-  int major=  version/10000;
-  int minor=  (version%10000)/100;
-  int patch=  version%100;
-  sprintf(s,FMT01, major , minor, patch);
-  writeConsole(s);
-
+  /* Call the main control function */
   if (strlen(f2)> 0) {
      /* use stdout for progress messages */
      errcode = ENepanet(f1,f2,f3,writeConsole);
@@ -84,18 +94,27 @@ int   main(int argc, char *argv[])
   }
 
   /* Error/Warning check   */
-  if (errcode == 0)   writeConsole(FMT09);
+  if (errcode == 0) {
+     /* no errors */
+     writeConsole(FMT09);
+     return(0);
+  }
   else {
-     if (errcode > 100) {
+     ENgeterror(errcode, errmsg, MAXMSG);
+     writeConsole(errmsg);
+     if (errcode > MAXWARNCODE) {
+     	/* error */
         writeConsole(FMT11);
+        return(errcode);
      }
      else {
+     	  /* warning */
         writeConsole(FMT10);
+        return(0);
      }
-    ENgeterror(errcode, errmsg, 40);
-    writeConsole(errmsg);
   }
-  return(0);
+
+
 }                                       /* End of main */
 
 

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -180,7 +180,7 @@ int DLLEXPORT ENepanet(char *f1, char *f2, char *f3, void (*pviewprog) (char *))
     ERRCODE(ENsolveQ());
     ERRCODE(ENreport());
     ENclose();
-    return(errcode);
+    return(MAX(errcode, Warnflag) );
 }
 
 
@@ -290,7 +290,7 @@ int DLLEXPORT ENclose()
    }                                                                           //(2.00.12 - LR)
 
    if (InFile  != NULL) { fclose(InFile);  InFile=NULL;  }
-   if (RptFile != NULL) { fclose(RptFile); RptFile=NULL; }
+   if (RptFile != NULL && RptFile != stdout) { fclose(RptFile); RptFile=NULL; }
    if (HydFile != NULL) { fclose(HydFile); HydFile=NULL; }
    if (OutFile != NULL) { fclose(OutFile); OutFile=NULL; }
   
@@ -3499,8 +3499,8 @@ void  writecon(char *s)
 */
 {
                                                     //(2.00.11 - LR)
-   fprintf(stdout,s);
-   fflush(stdout);
+   //fprintf(stdout,s);
+   //fflush(stdout);
 
 }
 
@@ -3514,14 +3514,12 @@ void writewin(char *s)
 **----------------------------------------------------------------
 */
 {
-#ifdef DLL
    char progmsg[MAXMSG+1];
    if (viewprog != NULL)
    {
       strncpy(progmsg,s,MAXMSG);
       viewprog(progmsg);
    }
-#endif
 }
 
 

--- a/src/output.c
+++ b/src/output.c
@@ -503,6 +503,7 @@ int  savefinaloutput()
       ERRCODE(savetimestat(x,LINKHDR));
       if (!errcode) Nperiods = 1;
       fclose(TmpOutFile);
+      TmpOutFile=NULL;
       free(x);
    }
 


### PR DESCRIPTION
now Warnflag is retuned with errorcode from ENepanet function
modified main.c  
* new use of return value from ENepanet
  * errcode==0  no errors, no warnings)
  *  0< errcode < 100    warnings
  * errcode > 100 errors
* if second argument  argv[2] is absent or null string redirects report file to stdout
* if error/warning reports error message (otherwise it can be difficult to understand because error is not reported in any other place, i.e. "File Error 302: cannot open input file.")
* added version numbering from epanet shared library (ENgetversion ) instead of hardcoded string
Updating constant CODEVERSION (found in TYPES.H) will be sufficient
* string used by main.c included in main.c (instead of text.h)

now main.c is a stand alone code and depends only from epanet2.h and epanet2.dll/.so library

removed status messages direct writing to stdout (  writecon function)
write only with writewin function (avoids annoing messages to stdout when library is called by external programs)