### PR TITLE
Update epanet.c

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -285,9 +285,9 @@ int DLLEXPORT ENclose()
    if (TmpOutFile != OutFile)                                                  //(2.00.12 - LR)
    {                                                                           //(2.00.12 - LR)
       if (TmpOutFile != NULL) fclose(TmpOutFile);                              //(2.00.12 - LR)
-      TmpOutFile=NULL;
       remove(TmpFname);                                                        //(2.00.12 - LR)
    }                                                                           //(2.00.12 - LR)
+   TmpOutFile=NULL;
 
    if (InFile  != NULL) { fclose(InFile);  InFile=NULL;  }
    if (RptFile != NULL && RptFile != stdout) { fclose(RptFile); RptFile=NULL; }


### PR DESCRIPTION
In `openoutfile()`, if timeseries output is requested (`Tstatflag == SERIES`) then `TmpOutFile` is set to `OutFile` instead of a new opened tmp file  (`TmpOutFile` and `OutFile` point to  the same object).

Later, when `ENclose()` closes all opened files, it closes and nullifies `OutFile` but not `TmpOutFile`.
`TmpOutFile` becomes a **dangling pointer** and (under Linux) it crashes (segmentation fault) when `fclose()`d

Issue can be reproduced as explained in #64 

Proposed solution nullifies `TmpOutFile` before `fclose(OutFile)`