### PR TITLE
Energy Computation for RuleBased Controls-OptionA

### DIFF
--- a/src/funcs.h
+++ b/src/funcs.h
@@ -115,6 +115,9 @@ int     allocrules(void);                 /* Allocates memory for rule  */
 int     ruledata(void);                   /* Processes rule input data  */
 int     checkrules(long);                 /* Checks all rules           */
 void    freerules(void);                  /* Frees rule base memory     */  
+int     rules(void);                      /* Updates link settings for rule-based controls */
+int     takeactions(void);                /* Implements actions on action list */
+void    clearactlist(void);               /* Clears memory used for action list */
 
 /* ------------- REPORT.C --------------*/
 int     writereport(void);                /* Writes formatted report    */

--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -196,6 +196,7 @@ int   runhyd(long *t)
    *t = Htime;
    demands();
    controls();
+   rules(); 
 
    /* Solve network hydraulic equations */
    errcode = netsolve(&iter,&relerr);


### PR DESCRIPTION
There is a problem in computing the energy when rule-based controls are
used: EPANET updates the settings of pumps BEFORE computing the energy.
For example, a pump is operating at time 0 and needs to be switched off
after 360 seconds. When EPANET finds the time step (360 seconds), it
also updates the pump status to be off. After this, the energy is
computed, but, because the pump status is already 'off' at this point,
the energy consumption is zero.

There are two possible corrections (that I can think of):
- Option A: when the timestep is computed, rule-based controls are only
  checked, without actually updating the pump statuses. Pump statuses will
  be updated after the energy computation (and, in particular, after
  having updated patterns and simple controls);
- Option B: the energy is computed based on the OLD status of the pump

Here is option A, which is the one described in the paper
(http://ascelibrary.org/doi/abs/10.1061/%28ASCE%29WR.1943-5452.0000637).
I will try to upload option B soon.

Option A has the disadvantage that rules are checked twice. The code for
option B has less modifications (and rules are checked only once), but
maybe the code is less readable as it uses the old setting of the pump
(which is a new introduced variable).
Another difference is that in Option A, the initial status is directly
updated according to the rules (so the value inserted as 'initial
status' may not be used).

I don't know which version is better and I am happy for the committee to
choose one. (There may be other better ways to correct the problem too,
but I couldn't find them).
Please, let me know if you have comments, questions or something is not
clear. Thank you.
