### PR TITLE
Energy Computation for RuleBased Controls-OptionB

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -2574,6 +2574,7 @@ void initpointers()
    LinkStatus        = NULL;
    LinkSetting        = NULL;
    OldStat  = NULL;
+   OldLinkSet	= NULL; 
 
    Node     = NULL;
    Link     = NULL;
@@ -2651,10 +2652,12 @@ int  allocdata()
       Q    = (double *) calloc(n, sizeof(double));
       LinkSetting    = (double *) calloc(n, sizeof(double));
       LinkStatus    = (char  *) calloc(n, sizeof(char));
+	  OldLinkSet    = (double *) calloc(MaxPumps+1, sizeof(double)); 
       ERRCODE(MEMCHECK(Link));
       ERRCODE(MEMCHECK(Q));
       ERRCODE(MEMCHECK(LinkSetting));
       ERRCODE(MEMCHECK(LinkStatus));
+	  ERRCODE(MEMCHECK(OldLinkSet)); 
    } 
 
 /* Allocate memory for tanks, sources, pumps, valves,   */
@@ -2775,6 +2778,7 @@ void  freedata()
     free(Q);
     free(LinkSetting);
     free(LinkStatus);
+	free(OldLinkSet);
 
 /* Free memory for node data */
     if (Node != NULL)

--- a/src/vars.h
+++ b/src/vars.h
@@ -149,6 +149,7 @@ EXTERN double         *NodeDemand,           /* Node actual demand           */
                 *NodeQual,             /* Node actual quality          */
                 *E,                    /* Emitter flows                */
                 *LinkSetting,          /* Link settings                */
+				*OldLinkSet,		   /* Link setting at previous time step */
                 *Q,                    /* Link flows                   */
                 *PipeRateCoeff,        /* Pipe reaction rate           */
                 *X,                    /* General purpose array        */


### PR DESCRIPTION
There is a problem in computing the energy when rule-based controls are
used: EPANET updates the settings of pumps BEFORE computing the energy.
For example, a pump is operating at time 0 and needs to be switched off
after 360 seconds. When EPANET finds the time step (360 seconds), it
also updates the pump status to be off. After this, the energy is
computed, but, because the pump status is already 'off' at this point,
the energy consumption is zero.

There are two possible corrections (that I can think of):
- Option A: when the timestep is computed, rule-based controls are only
  checked, without actually updating the pump statuses. Pump statuses will
  be updated after the energy computation (and, in particular, after
  having updated patterns and simple controls);
- Option B: the energy is computed based on the OLD status of the pump

Here is Option B (please, note that this version contains also the
changes for computing the efficiency of variable speed pumps, because
those lines would need to be modified).

Option A has the disadvantage that rules are checked twice. The code for
option B has less modifications (and rules are checked only once), but
maybe the code is less readable as it uses the old setting of the pump
(which is a new introduced variable).
Another difference is that in Option A, the initial status is directly
updated according to the rules (so the value inserted as 'initial
status' may not be used).

I don't know which version is better and I am happy for the committee to
choose one. (There may be other better ways to correct the problem too,
but I couldn't find them).
Please, let me know if you have comments, questions or something is not
clear. Thank you.

P.S.: I have just seen that I cannot automatically merge the files. I will create the pull request in any case (so that you can see the changes) and I will try to correct the problem later (but I think I will need some help in identifying the problem). 
