### PR TITLE
Require rpt file

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -290,7 +290,7 @@ int DLLEXPORT ENclose()
    TmpOutFile=NULL;
 
    if (InFile  != NULL) { fclose(InFile);  InFile=NULL;  }
-   if (RptFile != NULL && RptFile != stdout) { fclose(RptFile); RptFile=NULL; }
+   if (RptFile != NULL) { fclose(RptFile); RptFile=NULL; }
    if (HydFile != NULL) { fclose(HydFile); HydFile=NULL; }
    if (OutFile != NULL) { fclose(OutFile); OutFile=NULL; }
   

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -2400,7 +2400,7 @@ int   openfiles(char *f1, char *f2, char *f3)
       writecon(f1);
       return(302);
    }
-   if (strlen(f2) == 0) RptFile = stdout;
+   if (strlen(f2) == 0) return(303);
    else if ((RptFile = fopen(f2,"wt")) == NULL)
    {
       writecon(FMT06);


### PR DESCRIPTION
Dear Maintainers,  

The changes in this PR were made to pass checks required of compiled C code in R packages.  I submit it here for possible inclusion in the next release of EPANET.    

Compiled C code in R packages shouldn't write to stdout.  

I completely understand if allowing reporting to stdout is the preferred behavior.  Feel free to reject the PR in that case. 
