### PR TITLE
Format arg

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -954,7 +954,7 @@ void  ruleerrmsg(int err)
       strcat(label,Rule[Nrules].label);
    }
    else strcpy(label,t_RULES_SECT);
-   sprintf(Msg,fmt);
+   sprintf(Msg,"%s",fmt);
    strcat(Msg,label);
    strcat(Msg,":");
    writeline(Msg);


### PR DESCRIPTION
Dear Maintainers,  
The change in this PR were made to pass checks required of compiled C code in R packages.  I submit it here for possible inclusion in the next release of EPANET.    

calls to sprintf() should include a format string 
