### PR TITLE
use docker image to package build dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
   - cd ..
 
 script:
-  - docker run -v .:/epanet openwateranalytics/epanet_builder:latest bash -c "mkdir $BUILD_HOME && cd $BUILD_HOME && cmake .. -DBUILD_TESTS=1 && make && cd ../tests/regression && pipenv install && pipenv run python3 run_test.py $TEST_HOME 2012gcc 1.0.1 $TRAVIS_COMMIT /epanet/$BUILD_HOME/bin/runepanet"
+  - docker run -v $EPANET_HOME:/epanet openwateranalytics/epanet_builder:latest bash -c "mkdir $BUILD_HOME && cd $BUILD_HOME && cmake .. -DBUILD_TESTS=1 && make && cd ../tests/regression && pipenv install && pipenv run python3 run_test.py $TEST_HOME 2012gcc 1.0.1 $TRAVIS_COMMIT /epanet/$BUILD_HOME/bin/runepanet"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+sudo: required
 language: python
 
 python:
   - "3.6"
+
+services:
+  - docker
 
 env:
   global:
@@ -11,24 +15,12 @@ env:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libboost-test-dev
-  - sudo apt-get install libpcre3-dev bison
-  - wget -O swig-rel-3.0.12.tar.gz https://github.com/swig/swig/archive/rel-3.0.12.tar.gz && tar -xf swig-rel-3.0.12.tar.gz && cd swig-rel-3.0.12 && ./autogen.sh && ./configure && make -j 4 && sudo make install && cd ..
-  - pip install pipenv
 
-#install:
+install:
+  -
 
 before_script:
-  - mkdir -p $BUILD_HOME
-  - cd $BUILD_HOME
-  - cmake .. -DBUILD_TESTS=1
+  - cd ..
 
 script:
-  - cmake --build .
-  # run unit tests
-  - cd tests/unit
-  - ctest
-  # run regression tests
-  - cd $EPANET_HOME/tests/regression
-  - pipenv install
-  - pipenv run python3 run_test.py $TEST_HOME 2012gcc 1.0.1 $TRAVIS_COMMIT $EPANET_HOME/$BUILD_HOME/bin/runepanet
+  - docker run -v $BUILD_HOME:/epanet openwateranalytics/epanet_builder:latest bash -c "mkdir buildproducts && cd buildproducts && cmake .. -DBUILD_TESTS=1 && make && cd ../tests/regression && pipenv install && pipenv run python3 run_test.py $TEST_HOME 2012gcc 1.0.1 $TRAVIS_COMMIT /epanet/$BUILD_HOME/bin/runepanet"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
   - cd ..
 
 script:
-  - docker run -v $BUILD_HOME:/epanet openwateranalytics/epanet_builder:latest bash -c "mkdir buildproducts && cd buildproducts && cmake .. -DBUILD_TESTS=1 && make && cd ../tests/regression && pipenv install && pipenv run python3 run_test.py $TEST_HOME 2012gcc 1.0.1 $TRAVIS_COMMIT /epanet/$BUILD_HOME/bin/runepanet"
+  - docker run -v .:/epanet openwateranalytics/epanet_builder:latest bash -c "mkdir $BUILD_HOME && cd $BUILD_HOME && cmake .. -DBUILD_TESTS=1 && make && cd ../tests/regression && pipenv install && pipenv run python3 run_test.py $TEST_HOME 2012gcc 1.0.1 $TRAVIS_COMMIT /epanet/$BUILD_HOME/bin/runepanet"

--- a/tests/regression/test_local.py
+++ b/tests/regression/test_local.py
@@ -20,3 +20,5 @@ ret = run_tests(
 )
 
 print('run_tests returned {}'.format(ret))
+
+sys.exit(ret)


### PR DESCRIPTION
this ended up being pretty cool! 

old travis config, building and installing everything: 4m17s
new config, using docker: 2m45

... I think there's a way to cache the docker image in Travis, which will lead to better savings.