### PR TITLE
Dev test

### DIFF
--- a/.github/BuildAndTest.md
+++ b/.github/BuildAndTest.md
@@ -1,0 +1,183 @@
+## Building OWA EPANET From Source on Windows
+by Michael E. Tryby
+
+Created on: March 13, 2018 
+
+
+### Introduction
+
+Building OWA's fork of EPANET from source is a basic skill that all developers 
+interested in contributing to the project should know how to perform. This 
+document describes the build process step-by-step. You will learn 1) how to 
+configure your machine to build the project locally; 2) how to obtain the 
+project files using git; 3) how to use cmake to generate build files and build 
+the project; and 4) how to use ctest and nrtest to perform unit and regression 
+testing on the build artifacts produced. Be advised, you will need local admin 
+privileges on your machine to follow this tutorial. Let’s begin! 
+
+### Dependencies
+
+Before the project can be built the required tools must be installed. The OWA 
+EPANET project adheres to a platform compiler policy - for each platform there 
+is a designated compiler. The platform compiler for Windows is Visual 
+Studio cl, for Linux gcc, and for Mac OS clang. These instructions describe how
+to build EPANET on Windows. CMake is a cross platform build, testing, and packaging 
+tool that is used to automate the EPANET build workflow. Boost is a free portable 
+peer-reviewed C++ library. Unit tests are linked with Boost unit test libraries. 
+Lastly, git is a free and open source distributed version control system. Git must 
+be installed to obtain the project source code from the OWA EPANET repository 
+found on GitHub. 
+
+### Summary of Build Dependencies
+  - Platform Compiler
+    - Windows: Visual Studio 10.0 32-bit cl (version 16.00.40219.01 for 80x86)
+  - CMake (version 3.0.0 or greater)
+  - Boost Libraries (version 1.58 or greater)
+  - git (version 2.6.0 or greater)
+
+### Build Procedure
+1. Install Dependencies
+  * A. Install Visual Studio 2010 Express and SP1
+    Our current benchmark platform and compiler is Windows 32-bit Visual Studio 10 
+    2010. Older versions of Visual Studio are available for download here:  
+
+    https://www.visualstudio.com/vs/older-downloads/ 
+
+    A service pack for Visual Studio 10 2010 is available here: 
+
+    https://www.microsoft.com/en-us/download/details.aspx?id=34677
+
+  * B. Install Boost 
+    Boost binaries for Windows offer a convenient installation solution. Be sure to 
+    select for download the boost installer exe that corresponds to the version of Visual Studio you have installed. 
+
+    https://sourceforge.net/projects/boost/files/boost-binaries/1.58.0/
+
+    Although newer version of Boost are available, a link to Boost 1.58 is provided. This is the library version that the unit tests have been written against. Older versions of Boost may not work. The default install location for the Boost 
+    Libraries is C:\local\boost_1_58_0
+
+  * C. Install Chocolatey, CMake, and git
+    Chocolatey is a Windows package manager that makes installing some of these 
+    dependencies a little easier. When working with Chocolatey it is useful to have 
+    local admin privileges. Chocolatey is available here:
+
+    https://chocolatey.org/install
+
+    Once Chocolately is installed, from a command prompt running with admin privileges 
+    issue the following commands
+    ```
+    \>choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=User'
+    \>choco install -y git --installargs /GitOnlyOnPath
+    \>refreshenv
+    ```
+
+  * D. Common Problems
+    Using chocolatey requires a command prompt with admin privileges. 
+    Check to make sure installed applications are on the command path. 
+    Make note of the Boost Library install location. 
+
+
+2. Build The Project
+  As administrator open a Visual Studio 2010 Command Prompt. Change directories to 
+  the location where you wish to build the EPANET project. Now we will issue a series 
+  of commands to create a parent directory for the project root and clone the project
+  from OWA's GitHub repository.  
+
+  * A. Clone the EPANET Repository
+    ```
+    \>mkdir OWA
+    \>cd OWA
+    \>git clone --branch=dev https://github.com/OpenWaterAnalytics/EPANET.git
+    \>cd EPANET
+    ```
+  The present working directory is now the project root EPANET. The directory contains 
+  the same files that are visibly present in the GitHub Repo by browsing to the URL
+  https://github.com/OpenWaterAnalytics/EPANET/tree/dev. 
+
+  Now we will create a build products directory and generate the platform build 
+  file using cmake.  
+
+  * B. Generate the build files
+    ```
+    \>mkdir buildprod
+    \>cd buildprod
+    \>set BOOST_ROOT=C:\local\boost_1_58_0
+    \>cmake -G "Visual Studio 10 2010" -DBOOST_ROOT="%BOOST_ROOT%" -DBoost_USE_STATIC_LIBS="ON" ..
+    ```
+  
+  Now that the dependencies have been installed and the build system has been 
+  generated, building EPANET is a simple CMake command. 
+
+  * C. Build EPANET
+    \>cmake --build . --config Debug
+    
+  * D. Common Problems
+    CMake may not be able to find the project CMakeLists.txt file or the Boost 
+    library install location. 
+
+
+3. Testing
+  Unit Testing uses Boost Unit Test library and CMake ctest as the test runner. 
+  Cmake has been configured to register tests with ctest as part of the build process. 
+
+  * A. Unit Testing
+    ```
+    \>cd tests
+    \>ctest -C Debug
+    ```
+  The unit tests run quietly. Ctest redirects stdout to a log file which can be 
+  found in the "tests\Testing\Temporary" folder. This is useful when a test fails.  
+
+  Regression testing is somewhat more complicated because it relies on Python 
+  to execute EPANET for each test and compare the binary files and report files. 
+  To run regression tests first python and any required packages must be installed. 
+  If Python is already installed on your local machine the installation of 
+  miniconda can be skipped.  
+
+  * B. Installing Regression Testing Dependencies
+    ```
+    cd ..\..
+    \>choco install -y miniconda --installargs '/AddToPath=1'
+    \>choco install -y curl
+    \>choco install -y 7zip 
+    \>refreshenv
+    \>pip install -r tools/requirements-appveyor.txt
+    ```
+
+  With Python and the necessary dependencies installed, regression testing can be run 
+  using the before-test and run-nrtest helper scripts found in the tools folder. The script 
+  before-test stages the test and benchmark files for nrtest. The script run-nrtest calls 
+  nrtest execute and nrtest compare to perform the regression test. 
+
+  To run the executable under test, nrtest needs the absolute path to it and a 
+  unique identifier for it such as the version number. The project cmake build places build 
+  artifacts in the buildprod\bin\ folder. On Windows the build configuration "Debug" or 
+  "Release" must also be indicated. On Windows it is also necessary to specify the path to 
+  the Python Scripts folder so the nrtest execute and compare commands can be found. You 
+  need to substitute bracketed fields below like "<build identifier>" with the values for 
+  your setup. 
+
+  * C. Regression Testing
+    ```
+    \>tools\before-test.cmd <relative path to regression test location> <absolute path to exe under test> <build identifier>
+    \>tools\run-nrtest.cmd <absolute path to python scripts> <relative path to regression test location> <build identifier>
+    ```
+
+  * D. Common Problems
+  The batch file before-test.cmd needs to run with admin privileges. The nrtest script complains when it can't find manifest files. 
+
+That concludes this tutorial on building OWA EPANET from source on Windows. 
+You have learned how to configure your machine satisfying project dependencies 
+and how to acquire, build, and test EPANET on your local machine. To be sure, 
+there is a lot more to learn, but this is a good start! Learn more about project
+build and testing dependencies by following the links provided below. 
+
+### Further Reading
+  * Visual Studio - https://msdn.microsoft.com/en-us/library/dd831853(v=vs.100).aspx
+  * CMake - https://cmake.org/documentation/
+  * Boost - http://www.boost.org/doc/
+  * git - https://git-scm.com/doc
+  * Miniconda - https://conda.io/docs/user-guide/index.html
+  * curl - https://curl.haxx.se/
+  * 7zip - https://www.7-zip.org/
+  * nrtest - https://nrtest.readthedocs.io/en/latest/

--- a/tools/nrtest-epanet/main.py
+++ b/tools/nrtest-epanet/main.py
@@ -130,6 +130,8 @@ def nrtest_execute(app_path, test_path, output_path):
     exit(not success)
 
 
+import report_diff as rd
+
 if __name__ == "__main__":
 #    app_path = "apps\\swmm-5.1.11.json"
 #    test_path = "tests\\examples\\example1.json"
@@ -141,7 +143,9 @@ if __name__ == "__main__":
 #    print(nrtest_compare(test_path, ref_path, (0.001, 0.0)))
 
     benchmark_path = "C:\\Users\\mtryby\\Workspace\\GitRepo\\michaeltryby\\epanet-lr\\nrtestsuite\\benchmarks\\"
-    path_test = benchmark_path + "epanet-220dev\\example1\\example1.out"
-    path_ref  = benchmark_path + "epanet-2012\\example1\\example1.out"
+    path_test = benchmark_path + "epanet-220dev\\example2\\example2.out"
+    path_ref  = benchmark_path + "epanet-2012\\example2\\example2.out"
 
-    result_compare(path_test, path_ref, (0.001, 0.0))
+    #result_compare(path_test, path_ref, (0.001, 0.0))
+    rd.report_diff(path_test, path_ref, 2)
+    

--- a/tools/nrtest-epanet/nrtest_epanet/__init__.py
+++ b/tools/nrtest-epanet/nrtest_epanet/__init__.py
@@ -28,7 +28,7 @@ __copyright__ = "None"
 __credits__ = "Colleen Barr, Maurizio Cingi, Mark Gray, David Hall, Bryant McDonnell"
 __license__ = "CC0 1.0 Universal"
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __date__ = "September 6, 2017"
 
 __maintainer__ = "Michael Tryby"

--- a/tools/nrtest-epanet/nrtest_epanet/__init__.py
+++ b/tools/nrtest-epanet/nrtest_epanet/__init__.py
@@ -38,7 +38,7 @@ __status  = "Development"
 
 def epanet_allclose_compare(path_test, path_ref, rtol, atol):
     ''' 
-    Compares results in two EPANET binary files. Using the comparison criteria 
+    Compares results in two EPANET binary files using the comparison criteria 
     described in the numpy assert_allclose documentation. 
             
         (test_value - ref_value) <= atol + rtol * abs(ref_value) 
@@ -67,22 +67,67 @@ def epanet_allclose_compare(path_test, path_ref, rtol, atol):
     for (test, ref) in it.izip(ordr.output_generator(path_test), 
                                ordr.output_generator(path_ref)):
         
-        if len(test) != len(ref):
+        if len(test[0]) != len(ref[0]):
             raise ValueError('Inconsistent lengths')
         
         # Skip over arrays that are equal
-        if np.array_equal(test, ref):
+        if np.array_equal(test[0], ref[0]):
             continue
         else:
-            np.testing.assert_allclose(test, ref, rtol, atol)
+            np.testing.assert_allclose(test[0], ref[0], rtol, atol)
 
     return True
 
-# def epanet_better_compare(path_test, path_ref, rtol, atol):
-#     '''
-#     If you don't like assert_allclose you can add another function here. 
-#     '''
-#     pass
+
+def epanet_mincdd_compare(path_test, path_ref, rtol, atol):
+    '''
+    Compares the results of two EPANET binary files using a correct decimal
+    digits (cdd) comparison criteria:
+
+           min cdd(test, ref) >= atol
+
+    Returns true if min cdd in the file is greater than or equal to atol,
+    otherwise an AssertionError is thrown.
+
+    Arguments:
+        path_test - path to result file being testedgit
+        path_ref  - path to reference result file
+        rtol - ignored
+        atol - minimum allowable cdd value (i.e. 3)
+
+    Returns:
+        True
+
+    Raises:
+        ValueError()
+        AssertionError()
+    '''
+    min_cdd = 100.0
+
+    for (test, ref) in it.izip(ordr.output_generator(path_test), 
+                               ordr.output_generator(path_ref)):
+
+        if len(test[0]) != len(ref[0]):
+            raise ValueError('Inconsistent lengths')
+
+        # Skip over arrays that are equal
+        if np.array_equal(test[0], ref[0]):
+            continue
+        else:
+            diff = np.fabs(np.subtract(test[0], ref[0]))
+            idx = np.unravel_index(np.argmax(diff), diff.shape)
+
+            if diff[idx] != 0.0:
+                tmp =  - np.log10(diff[idx])
+
+                if tmp < min_cdd:
+                    min_cdd = tmp;
+
+    if np.floor(min_cdd) >= atol:
+        return True
+    else:
+        raise AssertionError('min_cdd=%d less than atol=%g' % (min_cdd, atol))
+
 
 def epanet_report_compare(path_test, path_ref, rtol, atol):
     '''

--- a/tools/nrtest-epanet/nrtest_epanet/__init__.py
+++ b/tools/nrtest-epanet/nrtest_epanet/__init__.py
@@ -118,7 +118,7 @@ def epanet_mincdd_compare(path_test, path_ref, rtol, atol):
             idx = np.unravel_index(np.argmax(diff), diff.shape)
 
             if diff[idx] != 0.0:
-                tmp =  - np.log10(diff[idx])
+                tmp = - np.log10(diff[idx])
 
                 if tmp < min_cdd:
                     min_cdd = tmp;

--- a/tools/nrtest-epanet/nrtest_epanet/output_reader.py
+++ b/tools/nrtest-epanet/nrtest_epanet/output_reader.py
@@ -23,7 +23,8 @@ def output_generator(path_ref):
     yield element attributes. It is useful for comparing contents of binary 
     files for numerical regression testing. 
     
-    The generator yields a Python list containing element attributes. 
+    The generator yields a Python tuple containing an array of element 
+    attributes and a tuple containing the element type, period, and attribute. 
     
     Arguments: 
         path_ref - path to result file
@@ -38,7 +39,8 @@ def output_generator(path_ref):
             for element_type in oapi.ElementType:
                 for attribute in br.elementAttributes[element_type]:
         
-                    yield br.element_attribute(element_type, period_index, attribute)
+                    yield (br.element_attribute(element_type, period_index, attribute), 
+                           (element_type, period_index, attribute))
 
 
 class OutputReader():    

--- a/tools/nrtest-epanet/report_diff.py
+++ b/tools/nrtest-epanet/report_diff.py
@@ -17,11 +17,9 @@ import numpy as np
 
 # project imports
 import nrtest_epanet.output_reader as ordr
-from numpy.f2py.auxfuncs import hasinitvalue
-from numpy.tests.test_numpy_version import test_valid_numpy_version
 
 
-def report_diff(path_test, path_ref, min_cdd):
+def _binary_diff(path_test, path_ref, min_cdd):
     for (test, ref) in it.izip(ordr.output_generator(path_test), 
                                ordr.output_generator(path_ref)):
         
@@ -32,16 +30,16 @@ def report_diff(path_test, path_ref, min_cdd):
         if np.array_equal(test[0], ref[0]):
             continue
         else:
-            lre = log_relative_error(test[0], ref[0])
+            lre = _log_relative_error(test[0], ref[0])
             idx = np.unravel_index(np.argmin(lre), lre.shape)
 
             if lre[idx] < min_cdd: 
-                print_diff(idx, lre, test, ref)
+                _print_diff(idx, lre, test, ref)
 
     return 
 
 
-def log_relative_error(q, c):
+def _log_relative_error(q, c):
     '''
     Computes log relative error, a measure of numerical accuracy. 
     
@@ -65,7 +63,7 @@ def log_relative_error(q, c):
     return np.negative(np.log10(re))
     
     
-def print_diff(idx, lre, test, ref):
+def _print_diff(idx, lre, test, ref):
     
     idx_val = (idx[0], ref[1])
     test_val = (test[0][idx[0]])
@@ -75,4 +73,24 @@ def print_diff(idx, lre, test, ref):
     
     print("Idx: %s\nSut: %f  Ref: %f  Diff: %f  LRE: %f\n" 
           % (idx_val, test_val, ref_val, diff_val, lre_val))
+
+
+def report(args):
+    _binary_diff(args.test, args.ref, args.mincdd)
+
+
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+    
+    parser = ArgumentParser(description='EPANET benchmark difference reporting')
+    parser.set_defaults(func=report)
+    parser.add_argument('-t', '--test', default=None, 
+                        help='Path to test benchmark')
+    parser.add_argument('-r', '--ref', default=None, 
+                        help='Path to reference benchmark')
+    parser.add_argument('-mc', '--mincdd', type=int, default=3, 
+                        help='Minimum correct decimal digits')
+    
+    args = parser.parse_args()
+    args.func(args)
     

--- a/tools/nrtest-epanet/report_diff.py
+++ b/tools/nrtest-epanet/report_diff.py
@@ -17,6 +17,8 @@ import numpy as np
 
 # project imports
 import nrtest_epanet.output_reader as ordr
+from numpy.f2py.auxfuncs import hasinitvalue
+from numpy.tests.test_numpy_version import test_valid_numpy_version
 
 
 def report_diff(path_test, path_ref, min_cdd):
@@ -52,7 +54,7 @@ def log_relative_error(q, c):
     diff = np.subtract(q, c)
     tmp_c = np.copy(c)
     # If ref value is small compute absolute error
-    tmp_c[np.fabs(tmp_c) <= 1.0e-6] = 1.0
+    tmp_c[np.fabs(tmp_c) < 1.0e-6] = 1.0
     
     re = np.fabs(diff)/np.fabs(tmp_c)
     # If re is tiny set lre to number of digits
@@ -64,5 +66,13 @@ def log_relative_error(q, c):
     
     
 def print_diff(idx, lre, test, ref):
-    print("LRE: %f\nIdx: %s\nSut: %f\nRef: %f\n" 
-          % ((lre[idx]),(idx[0], ref[1]),(test[0][idx[0]]),(ref[0][idx[0]])))
+    
+    idx_val = (idx[0], ref[1])
+    test_val = (test[0][idx[0]])
+    ref_val = (ref[0][idx[0]])
+    diff_val = (test_val - ref_val)
+    lre_val = (lre[idx[0]])
+    
+    print("Idx: %s\nSut: %f  Ref: %f  Diff: %f  LRE: %f\n" 
+          % (idx_val, test_val, ref_val, diff_val, lre_val))
+    

--- a/tools/nrtest-epanet/report_diff.py
+++ b/tools/nrtest-epanet/report_diff.py
@@ -47,8 +47,7 @@ def log_relative_error(q, c):
     
     Reference:
     McCullough, B. D. "Assessing the Reliability of Statistical Software: Part I."
-    The American Statistician, vol. 52, no. 4, 1998, pp. 358�366. 
-    JSTOR, JSTOR, www.jstor.org/stable/2685442.
+    The American Statistician, vol. 52, no. 4, 1998, pp. 358-366. 
     '''
     diff = np.subtract(q, c)
     tmp_c = np.copy(c)

--- a/tools/nrtest-epanet/report_diff.py
+++ b/tools/nrtest-epanet/report_diff.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+#
+#  report_diff.py 
+# 
+#  Date Created: July 11, 2018
+#
+#  Author:     Michael E. Tryby
+#              US EPA - ORD/NRMRL
+#
+
+# system imports
+import itertools as it
+
+# third party imports
+import numpy as np
+
+# project imports
+import nrtest_epanet.output_reader as ordr
+
+
+def report_diff(path_test, path_ref, min_cdd):
+    for (test, ref) in it.izip(ordr.output_generator(path_test), 
+                               ordr.output_generator(path_ref)):
+        
+        if len(test[0]) != len(ref[0]):
+            raise ValueError('Inconsistent lengths')
+        
+        # Skip over arrays that are equal
+        if np.array_equal(test[0], ref[0]):
+            continue
+        else:
+            lre = log_relative_error(test[0], ref[0])
+            idx = np.unravel_index(np.argmin(lre), lre.shape)
+
+            if lre[idx] < min_cdd: 
+                print_diff(idx, lre, test, ref)
+
+    return 
+
+
+def log_relative_error(q, c):
+    '''
+    Computes log relative error, a measure of numerical accuracy. 
+    
+    Single precision machine epsilon is between 2^-24 and 2^-23.
+    
+    Reference:
+    McCullough, B. D. "Assessing the Reliability of Statistical Software: Part I."
+    The American Statistician, vol. 52, no. 4, 1998, pp. 358�366. 
+    JSTOR, JSTOR, www.jstor.org/stable/2685442.
+    '''
+    diff = np.subtract(q, c)
+    tmp_c = np.copy(c)
+    # If ref value is small compute absolute error
+    tmp_c[np.fabs(tmp_c) <= 1.0e-6] = 1.0
+    
+    re = np.fabs(diff)/np.fabs(tmp_c)
+    # If re is tiny set lre to number of digits
+    re[re < 1.0e-7] = 1.0e-7
+    # If re is very large set lre to zero
+    re[re > 2.0] = 1.0
+
+    return np.negative(np.log10(re))
+    
+    
+def print_diff(idx, lre, test, ref):
+    print("LRE: %f\nIdx: %s\nSut: %f\nRef: %f\n" 
+          % ((lre[idx]),(idx[0], ref[1]),(test[0][idx[0]]),(ref[0][idx[0]])))

--- a/tools/nrtest-epanet/setup.py
+++ b/tools/nrtest-epanet/setup.py
@@ -25,7 +25,7 @@ entry_points = {
 
 setup(
     name='nrtest-epanet',
-    version='0.4.0',
+    version='0.5.0',
     description="EPANET extension for nrtest",
     
     author="Michael E. Tryby",

--- a/tools/nrtest-epanet/setup.py
+++ b/tools/nrtest-epanet/setup.py
@@ -17,6 +17,7 @@ except ImportError:
 entry_points = {
     'nrtest.compare': [
         'epanet allclose = nrtest_epanet:epanet_allclose_compare',
+        'epanet mincdd = nrtest_epanet:epanet_mincdd_compare',
         'epanet report = nrtest_epanet:epanet_report_compare',
         # Add entry point for new comparison functions here
     ]


### PR DESCRIPTION
This PR adds a command line tool for diffing epanet binary files `report_diff.py` and adds a new nrtest-epanet comparison function `epanet_mincdd_compare()` based on correct decimal digits comparison criteria. 

Running Unit Tests locally is still too complicated. This will be addressed in another PR. 

Partially addresses #216
Close #197 
