### PR TITLE
Add option to get\set default demand pattern

### DIFF
--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -138,6 +138,7 @@ Public Const EN_EMITEXPON = 3
 Public Const EN_DEMANDMULT = 4
 Public Const EN_HEADERROR = 5
 Public Const EN_FLOWCHANGE = 6
+Public Const EN_DEMANDDEFPAT = 7
 
 Public Const EN_LOWLEVEL = 0     ' Control types
 Public Const EN_HILEVEL = 1

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -219,13 +219,14 @@ typedef enum {           /* Demand model types. */
 
 /// Simulation Option codes
 typedef enum {
-  EN_TRIALS       = 0,
-  EN_ACCURACY     = 1,
-  EN_TOLERANCE    = 2,
-  EN_EMITEXPON    = 3,
-  EN_DEMANDMULT   = 4,
-  EN_HEADERROR    = 5,
-  EN_FLOWCHANGE   = 6
+  EN_TRIALS         = 0,
+  EN_ACCURACY       = 1,
+  EN_TOLERANCE      = 2,
+  EN_EMITEXPON      = 3,
+  EN_DEMANDMULT     = 4,
+  EN_HEADERROR      = 5,
+  EN_FLOWCHANGE     = 6,
+  EN_DEMANDDEFPAT   = 7
 } EN_Option;
 
 typedef enum {

--- a/tests/test_net_builder.cpp
+++ b/tests/test_net_builder.cpp
@@ -90,9 +90,11 @@ BOOST_AUTO_TEST_CASE(test_net_builder)
 
     error = EN_createproject(&ph);
     error = EN_init(ph, "net.rpt", "net.out", EN_GPM, EN_HW);
-    error = EN_addpattern(ph, (char *)"1");
+    error = EN_addpattern(ph, (char *)"pat1");
     BOOST_REQUIRE(error == 0);
     error = EN_setpattern(ph, 1, P, 12);
+    BOOST_REQUIRE(error == 0);
+    error = EN_setoption(ph, EN_DEMANDDEFPAT, 1);
     BOOST_REQUIRE(error == 0);
     for (i = 0; i < 9; i++)
     {
@@ -104,8 +106,8 @@ BOOST_AUTO_TEST_CASE(test_net_builder)
       BOOST_REQUIRE(error == 0);
       error = EN_setcoord(ph, i + 1, X[i], Y[i]);
       BOOST_REQUIRE(error == 0);
-      error = EN_setdemandpattern(ph, i + 1, 1, 1);
-      BOOST_REQUIRE(error == 0);
+      //error = EN_setdemandpattern(ph, i + 1, 1, 1);
+      //BOOST_REQUIRE(error == 0);
     }
     error = EN_addnode(ph, (char *)"9", EN_RESERVOIR);
     BOOST_REQUIRE(error == 0);


### PR DESCRIPTION
Also updates the net builder test. Take cares of #280 

In order to set the default pattern ID when setting the index to zero (for the case one wants to delete the default pattern), there is a need to use `DEFPATID` defined in [input1.c](https://github.com/OpenWaterAnalytics/EPANET/blob/dev/src/input1.c#L53). How can we make it global or should it be part of the project?