### PR TITLE
Fixes #317 (assigning head curves to pumps)

### DIFF
--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -787,7 +787,7 @@ extern "C" {
   int  DLLEXPORT ENgetheadcurveindex(int pumpIndex, int *curveIndex);
   
   /**
-   @brief Sets the curve id for a specified pump index.
+   @brief Sets the curve index for a specified pump index.
    @param pumpIndex The index of the pump
    @param curveIndex The index of the curve used by the pump
    @return Error code.

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -3973,13 +3973,14 @@ int DLLEXPORT EN_setheadcurveindex(EN_ProjectHandle ph, int index, int curveinde
   pump->Ptype = NOCURVE;
   pump->Hcurve = curveindex;
   // update pump parameters
-  getpumpparams(p);
+  findpumpcoeffs(p, pIdx);
+
   // convert units
   if (pump->Ptype == POWER_FUNC) {
     pump->H0 /= Ucf[HEAD];
     pump->R *= (pow(Ucf[FLOW], pump->N) / Ucf[HEAD]);
   }
-  /* Convert flow range & max. head units */
+  // Convert flow range & max. head units
   pump->Q0 /= Ucf[FLOW];
   pump->Qmax /= Ucf[FLOW];
   pump->Hmax /= Ucf[HEAD];

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -66,56 +66,11 @@ void    convertunits(EN_Project *pr);               /* Converts data to std. uni
 
 /* -------- INPUT2.C -------------------*/
 int     netsize(EN_Project *pr);                    /* Determines network size    */
-int     readdata(EN_Project *pr);                   /* Reads in network data      */
-int     newline(EN_Project *pr, int, char *);       /* Processes new line of data */
-int     addnodeID(EN_Network *n, int, char *);      /* Adds node ID to data base  */
-int     addlinkID(EN_Network *n, int, char *);      /* Adds link ID to data base  */
-int     addpattern(parser_data_t *par, char *);     /* Adds pattern to data base  */
-int     addcurve(parser_data_t *par, char *);       /* Adds curve to data base    */
-STmplist *findID(char *, STmplist *);               /* Locates ID on linked list  */
-int     unlinked(EN_Project *pr);                   /* Checks for unlinked nodes  */
-int     getpumpparams(EN_Project *pr);              /* Computes pump curve coeffs.*/
+int     findpumpcoeffs(EN_Project *pr, int);        /* Computes pump curve coeffs.*/
 int     getpatterns(EN_Project *pr);                /* Gets pattern data from list*/
-int     getcurves(EN_Project *pr);                  /* Gets curve data from list  */
 int     findmatch(char *, char *[]);                /* Finds keyword in line      */
 int     match(const char *, const char *);          /* Checks for word match      */
-int     gettokens(char *s, char** Tok, int maxToks,
-                  char *comment);                   /* Tokenizes input line       */
-int     getfloat(char *, double *);                 /* Converts string to double  */
-double  hour(char *, char *);                       /* Converts time to hours     */
 int     setreport(EN_Project *pr, char *);          /* Processes reporting command*/
-void    inperrmsg(EN_Project *pr, int,int,char *);  /* Input error message        */
-
-/* ---------- INPUT3.C -----------------*/
-int     juncdata(EN_Project *pr);                   /* Processes junction data    */
-int     tankdata(EN_Project *pr);                   /* Processes tank data        */
-int     pipedata(EN_Project *pr);                   /* Processes pipe data        */
-int     pumpdata(EN_Project *pr);                   /* Processes pump data        */
-int     valvedata(EN_Project *pr);                  /* Processes valve data       */
-int     patterndata(EN_Project *pr);                /* Processes pattern data     */
-int     curvedata(EN_Project *pr);                  /* Processes curve data       */
-int     coordata(EN_Project *pr);                   /* Processes coordinate data  */
-int     demanddata(EN_Project *pr);                 /* Processes demand data      */
-int     controldata(EN_Project *pr);                /* Processes simple controls  */
-int     energydata(EN_Project *pr);                 /* Processes energy data      */
-int     sourcedata(EN_Project *pr);                 /* Processes source data      */
-int     emitterdata(EN_Project *pr);                /* Processes emitter data     */
-int     qualdata(EN_Project *pr);                   /* Processes quality data     */
-int     reactdata(EN_Project *pr);                  /* Processes reaction data    */
-int     mixingdata(EN_Project *pr);                 /* Processes tank mixing data */
-int     statusdata(EN_Project *pr);                 /* Processes link status data */
-int     reportdata(EN_Project *pr);                 /* Processes report options   */
-int     timedata(EN_Project *pr);                   /* Processes time options     */
-int     optiondata(EN_Project *pr);                 /* Processes analysis options */
-int     optionchoice(EN_Project *pr, int);          /* Processes option choices   */
-int     optionvalue(EN_Project *pr, int);           /* Processes option values    */
-int     getpumpcurve(EN_Project *pr, int);          /* Constructs a pump curve    */
-int     powercurve(double, double, double,          /* Coeffs. of power pump curve*/
-                   double, double, double *,
-                   double *, double *);
-int     valvecheck(EN_Project *pr, int, int, int);  /* Checks valve placement     */
-void    changestatus(EN_Network *net, int, StatType,
-                     double);                       /* Changes status of a link   */
 
 /* -------------- RULES.C --------------*/
 void    initrules(rules_t *rules);                  /* Initializes rule base      */

--- a/src/input1.c
+++ b/src/input1.c
@@ -63,6 +63,8 @@ AUTHOR:     L. Rossman
 
 extern char *Fldname[]; /* Defined in enumstxt.h in EPANET.C      */
 extern char *RptFlowUnitsTxt[];
+extern int  readdata(EN_Project *pr);
+
 
 int getdata(EN_Project *pr)
 /*

--- a/src/input3.c
+++ b/src/input3.c
@@ -38,7 +38,44 @@ extern char *MixTxt[];
 extern char *Fldname[];
 extern char *DemandModelTxt[];
 
-/* Defined in INPUT2.C */
+// Imported Functions
+extern STmplist *findID(char *, STmplist *);
+extern int      addnodeID(EN_Network *n, int, char *);
+extern int      addlinkID(EN_Network *n, int, char *);
+extern int      getfloat(char *, double *);
+extern double   hour(char *, char *);
+
+// Exported Functions
+int  juncdata(EN_Project *pr);
+int  pipedata(EN_Project *pr);
+int  tankdata(EN_Project *pr);
+int  pumpdata(EN_Project *pr);
+int  valvedata(EN_Project *pr);
+int  patterndata(EN_Project *pr);
+int  curvedata(EN_Project *pr);
+int  coordata(EN_Project *pr);
+int  demanddata(EN_Project *pr);
+int  controldata(EN_Project *pr);
+int  energydata(EN_Project *pr);
+int  sourcedata(EN_Project *pr);
+int  emitterdata(EN_Project *pr);
+int  qualdata(EN_Project *pr);
+int  reactdata(EN_Project *pr);
+int  mixingdata(EN_Project *pr);
+int  statusdata(EN_Project *pr);
+int  reportdata(EN_Project *pr);
+int  timedata(EN_Project *pr);
+int  optiondata(EN_Project *pr);
+int  optionchoice(EN_Project *pr, int);
+int  optionvalue(EN_Project *pr, int);
+int  powercurve(double, double, double, double, double, double *, double *, double *);
+
+
+// Local Functions
+static int  getpumpcurve(EN_Project *pr, int);
+static int  valvecheck(EN_Project *pr, int, int, int);
+static void changestatus(EN_Network *net, int, StatType, double);
+
 
 int juncdata(EN_Project *pr)
 /*

--- a/src/rules.c
+++ b/src/rules.c
@@ -92,6 +92,11 @@ char *Value[] = {"XXXX", w_OPEN, w_CLOSED, w_ACTIVE, NULL};
 
 /* External variables declared in INPUT2.C */
 
+// Imported Functions
+extern int     getfloat(char *, double *);
+extern double  hour(char *, char *);
+
+
 /*
 **   Local function prototypes are defined here and not in FUNCS.H
 **   because some of them utilize the Premise and Action structures

--- a/src/types.h
+++ b/src/types.h
@@ -51,7 +51,7 @@ typedef  int          INT4;
 #define   TITLELEN  79       // Max. # characters in a title line
 #define   MAXID     31       /* Max. # characters in ID name           */      
 #define   MAXMSG    255      /* Max. # characters in message text      */
-#define   MAXLINE   255      /* Max. # characters read from input line */
+#define   MAXLINE   1024     /* Max. # characters read from input line */
 #define   MAXFNAME  259      /* Max. # characters in file name         */
 #define   MAXTOKS   40       /* Max. items per line of input           */
 #define   TZERO     1.E-4    /* Zero time tolerance                    */

--- a/tests/test_multiple_pumps.cpp
+++ b/tests/test_multiple_pumps.cpp
@@ -1,0 +1,166 @@
+//
+// test_multiple_pumps.cpp
+//
+
+#define BOOST_TEST_MODULE "toolkit"
+#include <boost/test/included/unit_test.hpp>
+
+#include <iostream>
+#include <string>
+#include "epanet2.h"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE (test_toolkit)
+
+BOOST_AUTO_TEST_CASE(test_multiple_pumps)
+{
+    int error = 0;
+    int flag = 00;
+    long t, tstep;
+    int i, ind;
+    float q_build_1, q_build_2, q_load_1, q_load_2;
+    
+    // first we build a network with 2 pumps, run it and record the flow in each pump
+    EN_ProjectHandle ph = NULL;
+    EN_createproject(&ph);
+    
+    error = EN_init(ph, "net.rpt", "net.out", EN_CMH, EN_HW);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_addnode(ph, (char *)"R1", EN_RESERVOIR);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, (char *)"J1", EN_JUNCTION);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, (char *)"J2", EN_JUNCTION);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, (char *)"J3", EN_JUNCTION);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, (char *)"J4", EN_JUNCTION);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, (char *)"R2", EN_RESERVOIR);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_addlink(ph, (char *)"P1", EN_PIPE, (char *)"R1", (char *)"J1");
+    BOOST_REQUIRE(error == 0);
+    error = EN_addlink(ph, (char *)"P2", EN_PIPE, (char *)"J2", (char *)"J4");
+    BOOST_REQUIRE(error == 0);
+    error = EN_addlink(ph, (char *)"P3", EN_PIPE, (char *)"J3", (char *)"J4");
+    BOOST_REQUIRE(error == 0);
+    error = EN_addlink(ph, (char *)"P4", EN_PIPE, (char *)"J4", (char *)"R2");
+    BOOST_REQUIRE(error == 0);
+
+
+
+    for (i = 0; i < 4; i++)
+    {
+      error = EN_setlinkvalue(ph, i + 1, EN_LENGTH, 100);
+      BOOST_REQUIRE(error == 0);
+      error = EN_setlinkvalue(ph, i + 1, EN_DIAMETER, 200);
+      BOOST_REQUIRE(error == 0);
+    }
+
+    error = EN_addlink(ph, (char *)"PU1", EN_PUMP, (char *)"J1", (char *)"J2");
+    BOOST_REQUIRE(error == 0);
+    error = EN_addlink(ph, (char *)"PU2", EN_PUMP, (char *)"J1", (char *)"J3");
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_addcurve(ph, (char *)"1");
+    BOOST_REQUIRE(error == 0);
+
+    EN_API_FLOAT_TYPE c1[3] = {100,200,300};
+    EN_API_FLOAT_TYPE c2[3] = {30,20,10};
+    
+    error = EN_setcurve(ph, 1, c1, c2, 3);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkindex(ph, (char *)"PU1", &ind);
+    BOOST_REQUIRE(error == 0);
+    error = EN_setheadcurveindex(ph, ind, 1);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_addcurve(ph, (char *)"2");
+    BOOST_REQUIRE(error == 0);
+    EN_API_FLOAT_TYPE c3[3] = {200,250,400};
+    EN_API_FLOAT_TYPE c4[3] = {40,25,10};
+    error = EN_setcurve(ph, 2, c3, c4, 3);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkindex(ph, (char *)"PU2", &ind);
+    BOOST_REQUIRE(error == 0);
+    error = EN_setheadcurveindex(ph, ind, 2);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_openH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_initH(ph, 0);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_runH(ph, &t);
+    cout << "\nGenerated Network has Error " << error;
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getlinkindex(ph, (char *)"PU1", &ind);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, ind, EN_FLOW, &q_build_1);
+    BOOST_REQUIRE(error == 0);
+    cout << "\nFlow from pump1: " << q_build_1;
+
+    error = EN_getlinkindex(ph, (char *)"PU2", &ind);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, ind, EN_FLOW, &q_build_2);
+    BOOST_REQUIRE(error == 0);
+    cout << "   Flow from pump2: " << q_build_2;
+    
+
+    error = EN_saveinpfile(ph, "net_builder.inp");
+    BOOST_REQUIRE(error == 0);
+    
+    error = EN_closeH(ph);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_close(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_deleteproject(&ph);
+    BOOST_REQUIRE(error == 0);
+
+    // ------------------------------------------------------------------------
+    // now we load the netwok we just built and saved
+    EN_createproject(&ph);
+    error = EN_open(ph, "net_builder.inp", "net_builder.rpt", "net_builder.out");
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_openH(ph);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_initH(ph, flag);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_runH(ph, &t);
+    cout << "\nSaved Network has Error " << error;
+    BOOST_REQUIRE(error == 0);
+    
+    error = EN_getlinkindex(ph, (char *)"PU1", &ind);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, ind, EN_FLOW, &q_load_1);
+    BOOST_REQUIRE(error == 0);
+    cout << "\nFlow from pump1: " << q_load_1;
+
+    error = EN_getlinkindex(ph, (char *)"PU2", &ind);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, ind, EN_FLOW, &q_load_2);
+    BOOST_REQUIRE(error == 0);
+    cout << "   Flow from pump2: " << q_load_2;
+
+    error = EN_closeH(ph);
+    BOOST_REQUIRE(error == 0);
+    
+    error = EN_close(ph);
+    BOOST_REQUIRE(error == 0);
+
+    EN_deleteproject(&ph); 
+
+    // compare the original to the build & saved network
+    BOOST_REQUIRE(q_build_1 == q_load_1);
+    BOOST_REQUIRE(q_build_2 == q_load_2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Removed need to recalculate curve coeffs. for all pumps when just a single pump is assigned a head curve.
- Added Abel Heinsbroek's unit test for multiple pumps.
- Replaced EN_geterror calls in input2.c with calls to geterrmsg (bad form to use API funcs in body of library).
- Moved declarations of many functions for input2.c and input3.c from funcs.h to the modules that utilize them.
- Increased max. size of line read from file (MAXLINE) to 1024 since comment lengths were increased to 256.