### PR TITLE
Removes writecon function from project (#300)

### DIFF
--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -7,7 +7,11 @@ Attribute VB_Name = "Module1"
 
 'Last updated on 4/3/07
 
+
 ' These are codes used by the DLL functions
+Public Const EN_MAXID = 31
+Public Const EN_MAXMSG = 255
+
 Public Const EN_ELEVATION = 0     ' Node parameters
 Public Const EN_BASEDEMAND = 1
 Public Const EN_PATTERN = 2

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -67,6 +67,9 @@
 
 // --- Define the EPANET toolkit constants
 
+#define  EN_MAXID  31  /**< Max. # characters in ID name */
+#define  EN_MAXMSG 255 /**< Max. # characters in message text */
+
 /// Node property codes
 typedef enum {
   EN_ELEVATION    = 0, /**< Node Elevation */

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -12,6 +12,9 @@ Imports System.Text
 Module Epanet2
 
 ' These are codes used by the DLL functions
+Public Const EN_MAXID = 31
+Public Const EN_MAXMSG = 255
+
 Public Const EN_ELEVATION = 0     ' Node parameters
 Public Const EN_BASEDEMAND = 1
 Public Const EN_PATTERN = 2

--- a/run/main.c
+++ b/run/main.c
@@ -1,33 +1,26 @@
-#include <stdio.h>
-#include <string.h>
-#include "epanet2.h"
-
-#define   MAXMSG         255       /* Max. # characters in message text      */
-#define   MAXWARNCODE    99      
-/* text copied here, no more need of include "text.h" */
-#define FMT01  "\nEPANET Version %d.%d.%d\n"
-#define FMT03 "\nUsage:\n %s <input_filename> <report_filename> [<binary_filename>]\n"
-#define FMT09  "\n\nEPANET completed.\n"
-#define FMT10  "\nEPANET completed. There are warnings.\n"
-#define FMT11  "\nEPANET completed. There are errors.\n"
-
-
-void  writeConsole(char *s);
-
-
 /*
 ----------------------------------------------------------------
-   Entry point used to compile a stand-alone executable.
+Command line executable for the EPANET water distribution system
+analysis program using the EPANET API library.
 ----------------------------------------------------------------
 */
 
+#include <stdio.h>
+#include "epanet2.h"
 
-int   main(int argc, char *argv[])
+// Function for writing progress messages to the console
+void  writeConsole(char *s)
+{
+    fprintf(stdout, "\r%s", s);
+    fflush(stdout);
+}
+
+int  main(int argc, char *argv[])
 /*--------------------------------------------------------------
  **  Input:   argc    = number of command line arguments
  **           *argv[] = array of command line arguments
  **  Output:  none
- **  Purpose: main program segment
+ **  Purpose: main program stub for command line EPANET
  **
  **  Command line for stand-alone operation is:
  **    progname f1  f2  f3
@@ -38,70 +31,62 @@ int   main(int argc, char *argv[])
  **--------------------------------------------------------------
  */
 {
-  char *f1,*f2,*f3;
-  char blank[] = "";
-  char errmsg[MAXMSG+1]="";
-  int  errcode;
-  int  version;
-  int major;
-  int minor;
-  int patch;
+    char *f1,*f2,*f3;
+    char blank[] = "";
+    char errmsg[EN_MAXMSG+1] = "";
+    int  errcode;
+    int  version;
+    int  major;
+    int  minor;
+    int  patch;
+    EN_ProjectHandle ph;
+    
+    // Check for proper number of command line arguments
+    if (argc < 2)
+    {
+        printf(
+    "\nUsage:\n %s <input_filename> <report_filename> [<binary_filename>]\n",
+        argv[0]);
+        return 0;
+    }
 
-  /* get version from DLL and trasform in Major.Minor.Patch format
-  instead of hardcoded version */
-  ENgetversion(&version);
-  major=  version/10000;
-  minor=  (version%10000)/100;
-  patch=  version%100;
-  printf(FMT01, major, minor, patch);
+    // Get version number and display in Major.Minor.Patch format
+    ENgetversion(&version);
+    major = version/10000;
+    minor = (version%10000)/100;
+    patch = version%100;
+    printf("\n... Running EPANET Version %d.%d.%d\n", major, minor, patch);
   
-  /* Check for proper number of command line arguments */
-  if (argc < 2) {
-    printf(FMT03, argv[0]);
-    return(1);
-  }
+    // Assign pointers to file names
+    f1 = argv[1];
+    if (argc > 2) f2 = argv[2];  // set rptfile name
+    else          f2 = blank;    // use stdout for rptfile
+    if (argc > 3) f3 = argv[3];  // set binary output file name
+    else          f3 = blank;    // no binary output file
 
-  /* set inputfile name */
-  f1 = argv[1];
-  if (argc > 2) {
-    /* set rptfile name */
-    f2 = argv[2];
-  }
-  else {
-    /* use stdout for rptfile */
-    f2 = blank;
-  }
-  if (argc > 3) {
-    /* set binary output file name */
-    f3 = argv[3];
-  }
-  else {
-    /* NO binary output*/
-    f3 = blank;
-  }
+    // Create a project and run it
+    errcode = EN_createproject(&ph);
+    errcode = EN_runproject(ph, f1, f2, f3, &writeConsole);
 
-  /* Call the main control function */
-  errcode = ENepanet(f1,f2,f3,NULL);
+    // Blank out the last progress message
+    printf("\r                                                               ");
 
-  /* Error/Warning check   */
-  if (errcode == 0) {
-     /* no errors */
-     printf(FMT09);
-     return(0);
-  }
-  else {
-     if (errcode > MAXWARNCODE) printf("\n    Fatal Error: ");
-     ENgeterror(errcode, errmsg, MAXMSG);
-     printf("%s\n", errmsg);
-     if (errcode > MAXWARNCODE) {
-        // error //
-        printf(FMT11);
-        return(errcode);
-     }
-     else {
-        // warning //
-        printf(FMT10);
-        return(0);
-     }
-  }
-}                                       /* End of main */
+    // Check for errors/warnings and report accordingly
+    if (errcode == 0)
+    {
+        printf("\n... EPANET ran successfully.\n");
+    }
+    else if (errcode < 100)
+    {
+        printf("\n... EPANET ran with warnings - check the Status Report.\n");
+    }
+    else
+    {
+        EN_geterror(errcode, errmsg, EN_MAXMSG);
+        printf("\n... EPANET failed with ERROR %d: %s.\n", errcode, errmsg);
+    }
+
+    // Delete the project
+    EN_deleteproject(&ph);
+    return errcode;
+}

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4610,6 +4610,7 @@ void errmsg(EN_Project *p, int errcode)
 **----------------------------------------------------------------
 */
 {
+    if (errcode < 100) return;  // Warnings are reported separately
     if (errcode != 309 && p->report.RptFile != NULL && p->report.Messageflag)
     {
         writeline(p, geterrmsg(errcode, p->Msg));

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4610,7 +4610,7 @@ void errmsg(EN_Project *p, int errcode)
 **----------------------------------------------------------------
 */
 {
-    if (errcode < 100) return;  // Warnings are reported separately
+    if (errcode < 100) errcode = -1;  // Warnings are reported separately
     if (errcode != 309 && p->report.RptFile != NULL && p->report.Messageflag)
     {
         writeline(p, geterrmsg(errcode, p->Msg));

--- a/src/errors.dat
+++ b/src/errors.dat
@@ -1,5 +1,13 @@
 
 DAT(0,EN_OK,"ok")
+
+DAT(1,ENWARN_UNBALANCED,"WARNING: System hydraulically unbalanced.")
+DAT(2,ENWARN_UNSTABLE,"WARNING: System may be hydraulically unstable.")
+DAT(3,ENWARN_DISCONNECTED,"WARNING: System disconnected.")
+DAT(4,ENWARN_PUMP_OFF_CURVE,"WARNING: Pumps cannot deliver enough flow or head.")
+DAT(5,ENWARN_LOW_VALVE_FLOW,"WARNING: Valves cannot deliver enough flow.")
+DAT(6,ENWARN_NEGATIVE_PRESSURES,"WARNING: System has negative pressures.")
+
 DAT(101,ENERR_INSUF_MEM,"insufficient memory available")
 DAT(102,ENERR_NO_NET_DATA,"no network data available")
 DAT(103,ENERR_HYD_NOT_INIT,"hydraulics not initialized")

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -52,7 +52,6 @@ int     findvalve(EN_Network *n, int);             /* Find valve index from node
 int     findpump(EN_Network *n, int);              /* Find pump index from node index */  // (AH)
 char   *geterrmsg(int errcode, char *msg);         /* Gets text of error message */
 void    errmsg(EN_Project *p, int);                /* Reports program error      */
-void    writecon(const char *);                    /* Writes text to console     */
 void    writewin(void (*vp)(char *), char *);      /* Passes text to calling app */
 
 /* ------- INPUT1.C --------------------*/

--- a/src/input2.c
+++ b/src/input2.c
@@ -34,7 +34,6 @@ The following utility functions are all called from INPUT3.C
 #include "hash.h"
 #include "text.h"
 #include "types.h"
-#include "epanet2.h"
 #include "funcs.h"
 #include <math.h>
 

--- a/src/report.c
+++ b/src/report.c
@@ -82,8 +82,6 @@ int writereport(EN_Project *pr)
   /* write formatted output to primary report file. */
   rep->Fprinterr = FALSE;
   if (rep->Rptflag && strlen(rep->Rpt2Fname) == 0 && rep->RptFile != NULL) {
-    writecon(FMT17);
-    writecon(rep->Rpt1Fname);
     if (rep->Energyflag)
       writeenergy(pr);
     errcode = writeresults(pr);
@@ -95,8 +93,6 @@ int writereport(EN_Project *pr)
     /* If secondary report file has same name as either input */
     /* or primary report file then use primary report file.   */
     if (strcomp(rep->Rpt2Fname, par->InpFname) || strcomp(rep->Rpt2Fname, rep->Rpt1Fname)) {
-      writecon(FMT17);
-      writecon(rep->Rpt1Fname);
       if (rep->Energyflag)
         writeenergy(pr);
       errcode = writeresults(pr);
@@ -117,8 +113,6 @@ int writereport(EN_Project *pr)
       /* Write full formatted report to file */
       else {
         rep->Rptflag = 1;
-        writecon(FMT17);
-        writecon(rep->Rpt2Fname);
         writelogo(pr);
         if (rep->Summaryflag)
           writesummary(pr);

--- a/src/text.h
+++ b/src/text.h
@@ -449,19 +449,15 @@ AUTHOR:     L. Rossman
 #define FMT82  "\n\f\n  Page %-d    %60.60s\n"
 
 /* ------------------- Progress Messages ---------------------- */
-#define FMT100 "Retrieving network data..."
-#define FMT101 "Computing hydraulics at hour %s"
-#define FMT102 "Computing water quality at hour %s"
-#define FMT103 "Saving results to file..."
+#define FMT100 "    Retrieving network data ...                   "
+#define FMT101 "    Computing hydraulics at hour %-10s       "
+#define FMT102 "    Computing water quality at hour %-10s    "
+#define FMT103 "    Writing output report ...                     "
+#define FMT106 "    Transferring results to file ...              "
 #define FMT104 "Analysis begun %s"
 #define FMT105 "Analysis ended %s"
 
 /*------------------- Error Messages --------------------*/
-
-
-
-
-
 #define R_ERR201 "Input Error 201: syntax error in following line of "
 #define R_ERR202 "Input Error 202: illegal numeric value in following line of "
 #define R_ERR203 "Input Error 203: undefined node in following line of "


### PR DESCRIPTION
The `writecon `function is a holdover from v.2.0 where it was only used when the entire code base was compiled into a command line executable and not a library. It's continued presence was causing progress messages to appear in console apps whether or not the app developer wanted them or not. To accomodate the removal of `writecon `a new version of `main.c` was written for the runnable version of the library.