### PR TITLE
Adding test_save_reopen, minor refactoring.

### DIFF
--- a/tests/test_demand_categories.cpp
+++ b/tests/test_demand_categories.cpp
@@ -20,53 +20,72 @@ A demand category name is set, the network is saved, reopened and the new demand
 
 using namespace std;
 
+boost::test_tools::predicate_result check_string(std::string test, std::string ref)
+{
+	if (ref.compare(test) == 0)
+		return true;
+	else
+		return false;
+}
+
 BOOST_AUTO_TEST_SUITE (test_toolkit)
 
 BOOST_AUTO_TEST_CASE(test_demand_categories)
 {
-    int error = 0;
-    int Nindex, ndem;
-    char demname[80];
-    EN_ProjectHandle ph = NULL;
+	string path_inp(DATA_PATH_INP);
+	string inp_save("net1_dem_cat.inp");
+	string path_rpt(DATA_PATH_RPT);
+	string path_out(DATA_PATH_OUT);
+
+	char node_id[] = "12";
+	char demand_category[] = "Demand category name";
+	char demname[80];
+
     
-    std::string path_inp = std::string(DATA_PATH_INP);
-    std::string path_rpt = std::string(DATA_PATH_RPT);
-    std::string path_out = std::string(DATA_PATH_OUT);
+	int error = 0;
+    int Nindex, ndem;
 
+    EN_ProjectHandle ph = NULL;
+	
     error = EN_createproject(&ph);
-    BOOST_REQUIRE(error == 0);
     error = EN_open(ph, path_inp.c_str(), path_rpt.c_str(), path_out.c_str());
-    BOOST_REQUIRE(error == 0);
-    error = EN_getnodeindex(ph, (char *)"12", &Nindex);
+
+    error = EN_getnodeindex(ph, node_id, &Nindex);
     BOOST_REQUIRE(error == 0);
     error = EN_getnumdemands(ph, Nindex, &ndem);
     BOOST_REQUIRE(error == 0);
-    BOOST_REQUIRE(ndem == 1);
-    error = EN_setdemandname(ph, Nindex, ndem, (char *)"Demand category name");
+    BOOST_CHECK(ndem == 1);
+    
+	error = EN_setdemandname(ph, Nindex, ndem, demand_category);
     BOOST_REQUIRE(error == 0);
-    error = EN_saveinpfile(ph, "net1_dem_cat.inp");
-    BOOST_REQUIRE(error == 0);
-    error = EN_close(ph);
-    BOOST_REQUIRE(error == 0);
-    error = EN_deleteproject(&ph);
+    error = EN_saveinpfile(ph, inp_save.c_str());
     BOOST_REQUIRE(error == 0);
 
+    error = EN_close(ph);
+	BOOST_REQUIRE(error == 0);
+	error = EN_deleteproject(&ph);
+	BOOST_REQUIRE(error == 0);
+
+	BOOST_TEST_CHECKPOINT("Reopening saved input file");
     error = EN_createproject(&ph);
-    BOOST_REQUIRE(error == 0);
-    error = EN_open(ph, "net1_dem_cat.inp", path_rpt.c_str(), path_out.c_str());
-    BOOST_REQUIRE(error == 0);
-    error = EN_getnodeindex(ph, (char *)"12", &Nindex);
+	BOOST_REQUIRE(error == 0); 
+	error = EN_open(ph, inp_save.c_str(), path_rpt.c_str(), path_out.c_str());
+	BOOST_REQUIRE(error == 0);
+
+    error = EN_getnodeindex(ph, node_id, &Nindex);
     BOOST_REQUIRE(error == 0);
     error = EN_getnumdemands(ph, Nindex, &ndem);
     BOOST_REQUIRE(error == 0);
-    BOOST_REQUIRE(ndem == 1);
-    error = EN_getdemandname(ph, Nindex, ndem, demname);
+    BOOST_CHECK(ndem == 1);
+
+	error = EN_getdemandname(ph, Nindex, ndem, demname);
     BOOST_REQUIRE(error == 0);
-    BOOST_REQUIRE(strcmp(demname, "Demand category name")==0);
-    error = EN_close(ph);
-    BOOST_REQUIRE(error == 0);
-    error = EN_deleteproject(&ph);
-    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(check_string(demname, demand_category));
+    
+	error = EN_close(ph);
+	BOOST_REQUIRE(error == 0); 
+	error = EN_deleteproject(&ph);
+	BOOST_REQUIRE(error == 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_setid.cpp
+++ b/tests/test_setid.cpp
@@ -22,38 +22,37 @@ BOOST_AUTO_TEST_SUITE (test_toolkit)
 
 BOOST_AUTO_TEST_CASE(test_setid)
 {
+	string path_inp(DATA_PATH_INP);
+	string path_rpt(DATA_PATH_RPT);
+	string path_out(DATA_PATH_OUT);
+
     int error = 0;
     int index;
-    string newid;
 
     EN_ProjectHandle ph = NULL;
     EN_createproject(&ph);
-    
-    std::string path_inp = std::string(DATA_PATH_INP);
-    std::string path_rpt = std::string(DATA_PATH_RPT);
-    std::string path_out = std::string(DATA_PATH_OUT);
     
     error = EN_open(ph, path_inp.c_str(), path_rpt.c_str(), "");
     BOOST_REQUIRE(error == 0);
 
     // Test of illegal node name change
-    newid = "Illegal; node name";
-    error = EN_setnodeid(ph, 3, (char *)newid.c_str());
+    char newid_1[] = "Illegal; node name";
+    error = EN_setnodeid(ph, 3, newid_1);
     BOOST_REQUIRE(error > 0);
 
     // Test of legal node name change
-    newid = "Node3";
-    error = EN_setnodeid(ph, 3, (char *)newid.c_str());
+    char newid_2[] = "Node3";
+    error = EN_setnodeid(ph, 3, newid_2);
     BOOST_REQUIRE(error == 0);
 
     // Test of illegal link name change
-    newid = "Illegal; link name";
-    error = EN_setlinkid(ph, 3, (char *)newid.c_str());
+    char newid_3[] = "Illegal; link name";
+    error = EN_setlinkid(ph, 3, newid_3);
     BOOST_REQUIRE(error > 0);
 
     // Test of legal link name change
-    newid = "Link3";
-    error = EN_setlinkid(ph, 3, (char *)newid.c_str());
+    char newid_4[] = "Link3";
+    error = EN_setlinkid(ph, 3, newid_4);
     BOOST_REQUIRE(error == 0);
 
     // Save the project
@@ -64,20 +63,21 @@ BOOST_AUTO_TEST_CASE(test_setid)
     BOOST_REQUIRE(error == 0);
     EN_deleteproject(&ph);
 
-    // Re-open the saved project
+    
+	// Re-open the saved project
     EN_createproject(&ph);
     error = EN_open(ph, "net1_setid.inp", path_rpt.c_str(), "");
     BOOST_REQUIRE(error == 0);
     
     // Check that 3rd node has its new name
-    error = EN_getnodeindex(ph, "Node3", &index);
+    error = EN_getnodeindex(ph, newid_2, &index);
     BOOST_REQUIRE(error == 0);
-    BOOST_REQUIRE(index == 3);
+    BOOST_CHECK(index == 3);
     
     // Check that 3rd link has its new name
-    error = EN_getlinkindex(ph, "Link3", &index);
+    error = EN_getlinkindex(ph, newid_4, &index);
     BOOST_REQUIRE(error == 0);
-    BOOST_REQUIRE(index == 3);
+    BOOST_CHECK(index == 3);
 
     error = EN_close(ph);
     BOOST_REQUIRE(error == 0);

--- a/tests/test_toolkit.cpp
+++ b/tests/test_toolkit.cpp
@@ -9,9 +9,13 @@
 
 //#define BOOST_TEST_DYN_LINK
 
+#ifdef _WIN32
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>
+#else
+#include <stdlib.h>
+#endif
 
 #define BOOST_TEST_MODULE "toolkit"
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
The new test - test_save_reopen - located in `test_toolkit.cpp` produces intermittent segfaults when built in Debug configuration. See Issue #339.  