### PR TITLE
Added additional network building features (#367)

### DIFF
--- a/ReleaseNotes2_2.md
+++ b/ReleaseNotes2_2.md
@@ -1,11 +1,10 @@
-Release Notes for EPANET 2.2 (Draft)
+﻿Release Notes for EPANET 2.2 (Draft)
 ============================
-
 This document describes the changes and updates that have been made to version 2.2 of EPANET.
 
 ## Thread-Safe API Functions
 
-A duplicate set of the version 2.1 API functions has been provided that allow multiple EPANET projects to be analyzed concurrently in a thread-safe manner. These functions maintain the same name as the original but use a `EN_` prefix instead of `EN`. In addition, the first argument to each of these functions is a handle that identifies the network data for the particular project being analyzed. For example, instead of writing:
+A duplicate set of API functions has been provided that allow multiple EPANET projects to be analyzed concurrently in a thread-safe manner. These functions maintain the same name as the original but use a `EN_` prefix instead of `EN`. In addition, the first argument to each of these functions is a handle that identifies the particular project being analyzed. For example, instead of writing:
 
 `ENgetnodevalue(nodeIndex, EN_ELEVATION, &elev)`
 
@@ -13,14 +12,14 @@ one would use:
 
 `EN_getnodevalue(ph, nodeIndex, EN_ELEVATION, &elev)`
 
-where `ph` is the handle assigned to the project.
+where `ph` is the handle assigned to the project. 
 
 Two new functions have been added to the API to manage the creation and deletion of project handles. `EN_createproject` creates a new project along with its handle, while `EN_deleteproject` deletes a project. An example of using the thread-safe version of the API is shown below:
 ```
-#include "epanet2.h"
+#include "epanet2_2.h"
 int runEpanet(char *finp, char *frpt)
 {
-    EN_ProjectHandle ph = 0;
+    EN_Project ph = 0;
     int err;
     err = EN_createproject(&ph);
     if (err) return err;
@@ -32,6 +31,35 @@ int runEpanet(char *finp, char *frpt)
     return err;
 }
 ```
+Prototypes of the thread-safe functions appear in the `epanet2_2.h` header file while `epanet2.h` contains prototypes of the legacy-style API functions. The enumerated constants used with both types of functions have been moved to `epanet2_enums.h`.
+
+## Network Building By Code
+
+API users now have the ability to build a complete EPANET network model using just function calls, without the need to open an EPANET-formatted input file. All types of network objects can be created and have their properties set using these calls, including both simple and rule-based controls.  Here is an example of building a simple 2-node, 1-pipe network just through code:
+```
+#include "epanet2_2.h"
+int buildandrunEpanet(char *frpt)
+{
+    EN_Project ph = 0;
+    int err;
+    err = EN_createproject(&ph);
+    if (err) return err;
+    EN_init(ph, frpt, "", EN_GPM, EN_HW);
+    EN_addnode(ph, "J1, EN_JUNCTION);
+    EN_setjuncdata(ph, 1, 710, 500, "");  //elev, demand
+    EN_addnode(ph, "R1", EN_RESERVOIR);
+    EN_setnodevalue(ph, 2, EN_ELEVATION, 800);
+    EN_addlink(ph, "P1", EN_PIPE, "R1", "J1");
+    EN_setpipedata(ph, 1, 5280, 14, 100, 0); // length, diam, C-factor
+    EN_setreport(ph, "NODES ALL");
+    err = EN_solveH(ph);
+    if (!err) err = EN_report(ph);
+    EN_close(ph);
+    EN_deleteproject(&ph);
+    return err;
+}
+```
+Instead of using `EN_open` to load data from a file, `EN_init` is used to initialize a project with the names of its report and binary files, and its flow units and head loss formula. The legacy-style API has a complementary set of functions for building networks from code. 
 
 ## Additional Convergence Parameters
 
@@ -44,16 +72,19 @@ Two new analysis options have been added to provide more rigorous convergence cr
 These new parameters augment the current `EN_ACCURACY` option which always remains in effect. In addition, both `EN_HEADERROR` and `EN_FLOWCHANGE` can be used as parameters in the `ENgetstatistic` (or `EN_getstatistic`) function to retrieve their computed values (even when their option values are 0) after a hydraulic solution has been completed.  
 
 ## Improved Linear Solver Routine
+
 EPANET's hydraulic solver requires solving a system of linear equations over a series of iterations until a set of convergence criteria are met. The coefficient matrix of this linear system is square and symmetric. It has a row for each network node and a non-zero off-diagonal coefficient for each link. The numerical effort needed to solve the linear system can be reduced if the nodes are re-ordered so that the non-zero coefficients cluster more tightly around the diagonal.
 
 EPANET's original node re-ordering scheme has been replaced by the more powerful **Multiple Minimum Degree (MMD)** algorithm. On a series of eight networks ranging in size from 7,700 to 100,000 nodes **MMD** reduced the solution time for a single period (steady state) hydraulic analysis by an average of 58%.
 
 ## Improved Handling of Near-Zero Flows
+
 EPANET's hydraulic solver can generate an ill-conditioned solution matrix when pipe flows approach zero unless some adjustment is made (i.e., as a pipe's flow approaches 0 its head loss gradient also approaches 0 causing its reciprocal, which is used to form the solution matrix's coefficients, to approach infinity). EPANET 2.0 used an arbitrary cutoff on head loss gradient to prevent it from becoming 0. This approach doesn't allow a pipe to follow any head loss v. flow relation in the region below the cutoff and can produce incorrect solutions for some networks (see [Estrada et al., 2009](https://ascelibrary.org/doi/full/10.1061/%28ASCE%29IR.1943-4774.0000100)).
 
 The hydraulic solver has been modified to use a linear head loss v. flow relation for flows approaching zero. For the Darcy-Weisbach equation, the linear Hagen-Poiseuille formula is used for laminar flow where the Reynolds Number is <= 2000. For the Hazen-Williams and Chezy-Manning equations, a flow limit `Qa` is established for each pipe, equal to the flow that produces the EPANET 2 gradient cutoff. For flows below this a linear head loss relation is used between 0 and the head loss at `Qa` and the gradient always equals the cutoff. EPANET 2.2 is now able to correctly solve the examples presented in Estrada et al. (2009) as well as those in [Gorev et al., (2013)](https://ascelibrary.org/doi/10.1061/%28ASCE%29HY.1943-7900.0000694) and [Elhay and Simpson (2011)](https://ascelibrary.org/doi/10.1061/%28ASCE%29HY.1943-7900.0000411).
 
 ## Pressure Dependent Demands
+
 EPANET has always employed a Demand Driven Analysis (**DDA**) when modeling network hydraulics. Under this approach nodal demands at a given point in time are fixed values that must be delivered no matter what nodal heads and link flows are produced by a hydraulic solution. This can result in situations where required demands are satisfied at nodes that have negative pressures - a physical impossibility. 
 
 To address this issue EPANET has been extended to use a Pressure Driven Analysis (**PDA**) if so desired. Under **PDA**, the demand *D* delivered at a node depends on the node's available pressure *P* according to:
@@ -63,7 +94,6 @@ To address this issue EPANET has been extended to use a Pressure Driven Analysis
 where *D<sub>f</sub>* is the full demand required, *P<sub>min</sub>* is the pressure below which demand is zero, *P<sub>req</sub>* is the pressure required to deliver the full required demand and *P<sub>exp</sub>* is an exponent. When *P < P<sub>min</sub>* demand is 0 and when *P > P<sub>req</sub>* demand equals *D<sub>f</sub>*.
 
 To implement pressure driven analysis four new parameters have been added to the [OPTIONS] section of the EPANET input file:
-
 
 | Parameter | Description  | Default |
 |--|--|--|
@@ -89,6 +119,7 @@ for the thread-safe API. Some additional points regarding the new **PDA** option
  - *P<sub>min</sub>* is allowed to equal to *P<sub>req</sub>*. This condition can be used to find a solution that results in the smallest amount of demand reductions needed to insure that no node delivers positive demand at a pressure below *P<sub>min</min>*.
 
 ## Improved Water Quality Mass Balance
+
 As described by [Davis et al. (2018)](https://www.drink-water-eng-sci.net/11/25/2018/dwes-11-25-2018.pdf) EPANET's water quality simulations can result in some significant mass balance errors when modeling short term mass injections (errors are much smaller for continuous source flows). The entire water quality engine has been re-written to eliminate these errors. It still uses the Lagrangian Time Driven transport method but now analyzes each network node in topologically sorted order rather than in arbitrary order.
 
 A Mass Balance Report now appears the end of a simulation's Status Report that lists the various components (inflow, outflow, reaction) that comprise the network's overall mass balance. In addition `EN_MASSBALANCE` can be used as a parameter in the `ENgetstatistic` (or `EN_getstatistic`) function to retrieve the Mass Balance Ratio (Total Outflow Mass / Total Inflow Mass) at any point during a water quality simulation.
@@ -106,95 +137,106 @@ Mass balance ratio (MBR) results for two of the networks analyzed by Davis et al
 
 Both network files are available [here](https://doi.org/10.23719/1375314).
 
-## Code Changes
-
- - The header file `vars.h` containing global variables has been eliminated. Instead a number of new structures incorporating these variables has been added to `types.h`. These structures have been incorporated into the new `EN_Project` structure, also defined in `types.h`, which gets passed into each of the thread-safe API functions as a pointer.
- - Each of the legacy API functions now simply calls its thread-safe counterpart passing in a pointer to a default global`EN_Project` variable that is declared in `types.h`.
- -  Throughout all code modules, global variables that were previously accessed through `vars.h` are now accessed using the `EN_Project` pointer that is passed into the functions where the variables appear.
- - The exceedingly long `hydraul.c` file has been split into four separate files:
-     - `hydraul.c` now contains just the code needed to initialize a hydraulic analysis, set demands and control actions at each time step, and determine the length of the next time step to take.
-     - `hydsolver.c` implements EPANET's hydraulic solver at a single point in time.
-     - `hydcoeffs.c` computes values of the matrix coefficients (derived from link head losses and their gradients) used by the hydraulic solver.
-     - `hydstatus.c` checks for status changes in valves and pumps as requested by the hydraulic solver.
- - The Multiple Minimum Degree re-ordering algorithm appears in a new file named `genmmd.c`. This is 1990's legacy code that is readily available on the web and can be found in several linear equation solver libraries.
- - The original `quality.c` file has also been split into three separate files:
-	 - `quality.c` initializes the quality solver and supervises the quality calculations over each simulation time step.
-	 - `qualreact.c` reacts the quality constituent within each pipe and tank over a single time step and also implements the various tank mixing models.
-	 - `qualroute.c` topologically sorts the network's nodes when flow directions change and implements the Lagrangian Time Driven transport algorithm over a single time step.
-
-## General changes
- - Read and write demand categories names
-
 ## New API functions
 |Function|Description|
 |--|--|
-|`ENinit`|Initializes an EPANET session|
-|`ENsetflowunits`|Sets the flow units|
-|`ENgetdemandmodel`|Retrieves the type of demand model in use and its parameters|
-|`ENsetdemandmodel`|Sets the type of demand model to use and its parameters|
-|`ENgetdemandname`|Sets the node's demand name for a category|
-|`ENsetdemandname`|Sets the node's demand name for a category|
-|`ENsetdemandpattern`|Sets the index of the demand pattern assigned to a node for a category index|
-|`ENsetheadcurveindex`|Sets the curve id for a specified pump index|
-|`ENgetrule`|Gets the number of premises, true actions, and false actions and the priority of an existing rule-based control|
-|`ENsetrulepriority`|Sets the priority of the existing rule-based control|
-|`ENgetpremise`|Gets the components of a premise/condition in an existing rule-based control|
-|`ENsetpremise`|Sets the components of a premise/condition in an existing rule-based control|
-|`ENsetpremiseindex`|Sets the index of an object in a premise of an existing rule-based control|
-|`ENsetpremisestatus`|Sets the status in a premise of an existing rule-based control|
-|`ENsetpremisevalue`|Sets the value in a premise of an existing rule-based control|
-|`ENgetthenaction`|Get the components of a THEN action in a rule-based control|
-|`ENsetthenaction`|Set the components of a THEN action in a rule-based control|
-|`ENgetelseaction`|Get the components of an ELSE action in a rule-based control|
-|`ENsetelseaction`|Set the components of an ELSE action in a rule-based control|
-|`ENgetruleID`|Returns the ID of a rule|
-|`ENgetcurvetype`|Get the type of a curve|
-|`ENsetlinknodes`|Set the indexes of a link's start- and end-nodes|
-|`ENsetlinktype`|Set the link type code for a specified link|
-|`ENaddnode`|Adds a new node|
-|`ENaddlink`|Adds a new link|
-|`ENaddcontrol`|Specify parameters to add a new simple control|
-|`ENaddrule`|Add a new control rule to the project|
-|`ENdeletenode`|Deletes a node|
-|`ENdeletelink`|Deletes a link|
-|`ENdeletecontrol`|Delete an existing simple control|
-|`ENdeleterule`|Delete a rule-based control|
-|`ENsetnodeid`|Change the ID name for a node|
-|`ENsetlinkid`|Change the ID name for a link|
+|`EN_createproject` | creates a new EPANET project |
+|`EN_deleteproject` | deletes an EPANET project |
+|`EN_init`|Initializes an EPANET project|
+|`EN_setflowunits`|Sets the project's flow units|
+|`EN_addnode`|Adds a new node to a project|
+|`EN_addlink`|Adds a new link to a project|
+|`EN_addcontrol`|Adds a new simple control to a project|
+|`EN_addrule`|Adds a new control rule to a project|
+|`EN_deletenode`|Deletes a node from the project|
+|`EN_deletelink`|Deletes a link from the project|
+|`EN_deletecontrol`|Deletes a simple control from the project|
+|`EN_deleterule`|Deletes a rule-based control from the project|
+|`EN_setnodeid`|Changes the ID name for a node|
+|`EN_setjuncdata` |Sets values for a junction's parameters |
+|`EN_settankdata` |Sets values for a tank's parameters| 
+|`EN_setlinkid`|Changes the ID name for a link|
+|`EN_setlinknodes`|Sets a link's start- and end-nodes|
+|`EN_setlinktype`|Changes the type of a specific link|
+|`EN_setpipedata`|Sets values for a pipe's parameters|
+|`EN_getdemandmodel`|Retrieves the type of demand model in use |
+|`EN_setdemandmodel`|Sets the type of demand model to use|
+|`EN_getdemandname`|Gets the name of a node's demand category|
+|`EN_setdemandname`|Sets the name of a node's demand category|
+|`EN_setdemandpattern`|Assigns a time pattern to a node's demand category |
+|`EN_getcurvetype`|Gets a curve's type|
+|`EN_setheadcurveindex`|Sets the index of a head curve used by a pump |
+|`EN_getrule`|Gets the number of elements in a rule-based control |
+|`EN_getruleid` | Gets the name assigned to a rule-based control |
+|`EN_getpremise`|Gets the contents of a premise in a rule-based control|
+|`EN_setpremise`|Sets the contents of a premise in a rule-based control|
+|`EN_setpremiseindex`|Sets the index of an object in a premise of a rule-based control|
+|`EN_setpremisestatus`|Sets the status of an object in a premise of a rule-based control|
+|`EN_setpremisevalue`|Sets the value of a property in a premise of a rule-based control|
+|`EN_getthenaction`|Gets the contents of a THEN action in a rule-based control|
+|`EN_setthenaction`|Sets the contents of a THEN action in a rule-based control|
+|`EN_getelseaction`|Gets the contents of an ELSE action in a rule-based control|
+|`EN_setelseaction`|Set the contents of an ELSE action in a rule-based control|
+|`EN_setrulepriority`|Sets the priority of a rule-based control|
+In addition to these new functions, a tank's volume curve `EN_VOLCURVE` can be set using `EN_setnodevalue` and `EN_setlinkvalue` can now be used to set the following pump properties:
+ - `EN_PUMP_POWER` (constant power rating)
+ - `EN_PUMP_HCURVE` (head characteristic curve)
+ - `EN_PUMP_ECURVE` (efficiency curve)
+ - `EN_PUMP_ECOST` (average energy price)
+ - `EN_PUMP_EPAT` (energy pricing pattern)
+ - `EN_LINKPATTERN` (speed setting pattern)
+ 
+Access to the following global energy options have been added to  `EN_getoption` and `EN_setoption`:
+ - `EN_GLOBALEFFIC` (global pump efficiency)
+ - `EN_GLOBALPRICE` (global average energy price per kW-Hour)
+ - `EN_GLOBALPATTERN`	(global energy price pattern)
+ - `EN_DEMANDCHARGE` (price per maximum kW of energy consumption)
 
-## API Extensions (additional definitions)
+## New API Constants
+
 ### Link value types:
-- `EN_EFFICIENCY`
-- `EN_HEADCURVE`
-- `EN_EFFICIENCYCURVE`
-- `EN_PRICEPATTERN`
-- `EN_STATE`
-- `EN_CONST_POWER`
-- `EN_SPEED`
+- `EN_PUMP_STATE`
+- `EN_PUMP_EFFIC`
+- `EN_PUMP_POWER`
+- `EN_PUMP_HCURVE`
+- `EN_PUMP_ECURVE`
+- `EN_PUMP_ECOST`
+- `EN_PUMP_EPAT`
+
 ### Count types:
  - `EN_RULECOUNT`
+
 ### Head loss formula:
  - `EN_HW`
  - `EN_DW`
  - `EN_CM`
-### Option types:
+
+### Hydraulic option types:
  - `EN_HEADERROR`
  - `EN_FLOWCHANGE`
- - `EN_DEMANDDEFPAT`
+ - `EN_DEFDEMANDPAT`
  - `EN_HEADLOSSFORM`
-### Time statistic types:
+ - `EN_GLOBALEFFIC`
+ - `EN_GLOBALPRICE`
+ - `EN_GLOBALPATTERN`
+ - `EN_DEMANDCHARGE`
+
+### Simulation statistic types:
  - `EN_MAXHEADERROR`
  - `EN_MAXFLOWCHANGE`
  - `EN_MASSBALANCE`
- ### Action code types:
+
+### Action code types:
  - `EN_UNCONDITIONAL`
  - `EN_CONDITIONAL`
+
 ### Curve types:
- - `EN_V_CURVE`
- - `EN_P_CURVE`
- - `EN_E_CURVE`
- - `EN_H_CURVE`
- - `EN_G_CURVE`
+ - `EN_VOLUME_CURVE`
+ - `EN_PUMP_CURVE`
+ - `EN_EFFIC_CURVE`
+ - `EN_HLOSS_CURVE`
+ - `EN_GENERIC_CURVE`
+
 ### Demand model types:
  - `EN_DDA`
  - `EN_PDA`

--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -5,7 +5,7 @@ Attribute VB_Name = "Module1"
 'Declarations of functions in the EPANET PROGRAMMERs TOOLKIT
 '(EPANET2.DLL)
 
-'Last updated on 4/3/07
+'Last updated on 01/01/2019
 
 ' These are codes used by the DLL functions
 Public Const EN_ELEVATION = 0     ' Node parameters
@@ -50,15 +50,16 @@ Public Const EN_HEADLOSS = 10
 Public Const EN_STATUS = 11
 Public Const EN_SETTING = 12
 Public Const EN_ENERGY = 13
-Public Const EN_LINKQUAL = 14   'ES
+Public Const EN_LINKQUAL = 14
 Public Const EN_LINKPATTERN = 15
-Public Const EN_EFFICIENCY = 16
-Public Const EN_HEADCURVE = 17
-Public Const EN_EFFICIENCYCURVE = 18
-Public Const EN_PRICEPATTERN = 19
-Public Const EN_STATE = 20
-Public Const EN_CONST_POWER = 21
-Public Const EN_SPEED = 22
+
+Public Const EN_PUMP_STATE = 16
+Public Const EN_PUMP_EFFIC = 17
+Public Const EN_PUMP_POWER = 18
+Public Const EN_PUMP_HCURVE = 19
+Public Const EN_PUMP_ECURVE = 20
+Public Const EN_PUMP_ECOST = 21
+Public Const EN_PUMP_EPAT = 22
 
 Public Const EN_DURATION = 0      ' Time parameters
 Public Const EN_HYDSTEP = 1
@@ -76,13 +77,13 @@ Public Const EN_QTIME = 12
 Public Const EN_HALTFLAG = 13
 Public Const EN_NEXTEVENT = 14
 
-Public Const EN_ITERATIONS = 0
+Public Const EN_ITERATIONS = 0    ' Run statistics
 Public Const EN_RELATIVEERROR = 1
 Public Const EN_MAXHEADERROR = 2
 Public Const EN_MAXFLOWCHANGE = 3
 Public Const EN_MASSBALANCE = 4
 
-Public Const EN_NODECOUNT = 0     'Component counts
+Public Const EN_NODECOUNT = 0     ' Component counts
 Public Const EN_TANKCOUNT = 1
 Public Const EN_LINKCOUNT = 2
 Public Const EN_PATCOUNT = 3
@@ -114,7 +115,7 @@ Public Const EN_MASS = 1
 Public Const EN_SETPOINT = 2
 Public Const EN_FLOWPACED = 3
 
-Public Const EN_HW = 0           ' Head loss formula
+Public Const EN_HW = 0            ' Head loss formulas
 Public Const EN_DW = 1
 Public Const EN_CM = 2
 
@@ -132,7 +133,7 @@ Public Const EN_CMD = 9
 Public Const EN_DDA = 0           ' Demand driven analysis
 Public Const EN_PDA = 1           ' Pressure driven analysis
 
-Public Const EN_TRIALS = 0       ' Misc. options
+Public Const EN_TRIALS = 0        ' Hydraulic options
 Public Const EN_ACCURACY = 1
 Public Const EN_TOLERANCE = 2
 Public Const EN_EMITEXPON = 3
@@ -141,40 +142,81 @@ Public Const EN_HEADERROR = 5
 Public Const EN_FLOWCHANGE = 6
 Public Const EN_DEMANDDEFPAT = 7
 Public Const EN_HEADLOSSFORM = 8
+Public Const EN_GLOBALEFFIC = 9
+Public Const EN_GLOBALPRICE = 10
+Public Const EN_GLOBALPATTERN = 11
+Public Const EN_DEMANDCHARGE = 12
 
-Public Const EN_LOWLEVEL = 0     ' Control types
+Public Const EN_LOWLEVEL = 0      ' Control types
 Public Const EN_HILEVEL = 1
 Public Const EN_TIMER = 2
 Public Const EN_TIMEOFDAY = 3
 
-Public Const EN_AVERAGE = 1      'Time statistic types
+Public Const EN_AVERAGE = 1       ' Time statistic types
 Public Const EN_MINIMUM = 2
 Public Const EN_MAXIMUM = 3
 Public Const EN_RANGE = 4
 
-Public Const EN_MIX1 = 0         'Tank mixing models
+Public Const EN_MIX1 = 0          ' Tank mixing models
 Public Const EN_MIX2 = 1
 Public Const EN_FIFO = 2
 Public Const EN_LIFO = 3
 
-Public Const EN_NOSAVE = 0       ' Save-results-to-file flag
+Public Const EN_NOSAVE = 0        ' Save-results-to-file flag
 Public Const EN_SAVE = 1
+Public Const EN_INITFLOW = 10     ' Re-initialize flow flag
+Public Const EN_SAVE_AND_INIT = 11
 
-Public Const EN_INITFLOW = 10    ' Re-initialize flow flag
+Public Const EN_CONST_HP = 0      ' Constant horsepower pump curve
+Public Const EN_POWER_FUNC = 1    ' Power function pump cuve
+Public Const EN_CUSTOM = 2        ' User-defined custom pump curve
+Public Const EN_NOCURVE = 3       ' No pump curve
 
-Public Const EN_CONST_HP = 0      ' constant horsepower
-Public Const EN_POWER_FUNC = 1    ' power function
-Public Const EN_CUSTOM = 2        ' user-defined custom curve
-Public Const EN_NOCURVE = 3       ' no curve
-
-Public Const EN_V_CURVE = 0       ' volume curve
-Public Const EN_P_CURVE = 1       ' pump curve
-Public Const EN_E_CURVE = 2       ' efficiency curve
-Public Const EN_H_CURVE = 3       ' head loss curve
-Public Const EN_G_CURVE = 4       ' General\default curve
+Public Const EN_VOLUME_CURVE = 0  ' Volume curve
+Public Const EN_PUMP_CURVE = 1    ' Pump curve
+Public Const EN_EFFIC_CURVE = 2   ' Efficiency curve
+Public Const EN_HLOSS_CURVE = 3   ' Head loss curve
+Public Const EN_GENERIC_CURVE = 4 ' Generic curve
 
 Public Const EN_UNCONDITIONAL = 0 ' Unconditional object deletion
 Public Const EN_CONDITIONAL = 1   ' Conditional object deletion
+
+Public Const EN_NO_REPORT = 0     ' No status report
+Public Const EN_NORMAL_REPORT = 1 ' Normal status report
+Public Const EN_FULL_REPORT = 2   ' Full status report
+
+Public Const EN_R_NODE   = 6      ' Rule objects
+Public Const EN_R_LINK   = 7
+Public Const EN_R_SYSTEM = 8
+
+Public Const EN_R_DEMAND    = 0   ' Rule variables
+Public Const EN_R_HEAD      = 1
+Public Const EN_R_GRADE     = 2
+Public Const EN_R_LEVEL     = 3
+Public Const EN_R_PRESSURE  = 4
+Public Const EN_R_FLOW      = 5
+Public Const EN_R_STATUS    = 6
+Public Const EN_R_SETTING   = 7
+Public Const EN_R_POWER     = 8
+Public Const EN_R_TIME      = 9
+Public Const EN_R_CLOCKTIME = 10
+Public Const EN_R_FILLTIME  = 11
+Public Const EN_R_DRAINTIME = 12
+
+Public Const EN_R_EQ    = 0       ' Rule operators
+Public Const EN_R_NE    = 1
+Public Const EN_R_LE    = 2
+Public Const EN_R_GE    = 3
+Public Const EN_R_LT    = 4
+Public Const EN_R_GT    = 5
+Public Const EN_R_IS    = 6
+Public Const EN_R_NOT   = 7
+Public Const EN_R_BELOW = 8
+Public Const EN_R_ABOVE = 9
+
+Public Const EN_R_IS_OPEN   = 1   ' Rule status types
+Public Const EN_R_IS_CLOSED = 2
+Public Const EN_R_IS_ACTIVE = 3
 
 'These are the external functions that comprise the DLL
 
@@ -236,6 +278,8 @@ Public Const EN_CONDITIONAL = 1   ' Conditional object deletion
  Declare Function ENgetnodetype Lib "epanet2.dll" (ByVal index As Long, code As Long) As Long
  Declare Function ENgetnodevalue Lib "epanet2.dll" (ByVal index As Long, ByVal code As Long, value As Single) As Long
  Declare Function ENsetnodevalue Lib "epanet2.dll" (ByVal index As Long, ByVal code As Long, ByVal value As Single) As Long
+ Declare Function ENsetjuncdata Lib "epanet2.dll" (ByVal index As Long, ByVal elev As Single, ByVal dmnd As Single, ByVal dmndpat As String) As Long
+ Declare Function ENsettankdata Lib "epanet2.dll" (ByVal index As Long, ByVal elev As Single, ByVal initlvl As Single, ByVal minlvl As Single, ByVal maxlvl As Single, ByVal diam As Single, ByVal minvol As Single, ByVal volcurve As String) As Long
  Declare Function ENgetcoord Lib "epanet2.dll" (ByVal index As Long, X As Single, Y As Single) As Long
  Declare Function ENsetcoord Lib "epanet2.dll" (ByVal index As Long, ByVal X As Single, ByVal Y As Single) As Long
  
@@ -262,6 +306,7 @@ Public Const EN_CONDITIONAL = 1   ' Conditional object deletion
  Declare Function ENsetlinknodes Lib "epanet2.dll" (ByVal index As Long, ByVal node1 As Long, ByVal node2 As Long) As Long
  Declare Function ENgetlinkvalue Lib "epanet2.dll" (ByVal index As Long, ByVal code As Long, value As Single) As Long
  Declare Function ENsetlinkvalue Lib "epanet2.dll" (ByVal index As Long, ByVal code As Long, ByVal value As Single) As Long
+ Declare Function ENsetpipedata Lib "epanet2.dll" (ByVal index As Long, ByVal length As Single, ByVal diam As Single, ByVal rough As Single, ByVal mloss As Single) As Long
 
 'Pump Functions
  Declare Function ENgetheadcurveindex Lib "epanet2.dll" (ByVal pumpIndex As Long, curveIndex As Long) As Long

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/29/2018
+ Last Updated: 12/31/2018
  ******************************************************************************
  */
 
@@ -44,12 +44,6 @@
       #endif // __cplusplus
     #elif defined(CYGWIN)
       #define DLLEXPORT __stdcall
-    #elif defined(__APPLE__)
-      #ifdef __cplusplus
-        #define DLLEXPORT
-      #else
-        #define DLLEXPORT
-      #endif
     #else
       #define DLLEXPORT
     #endif
@@ -511,6 +505,34 @@ extern "C" {
   int  DLLEXPORT ENsetnodevalue(int index, int code, EN_API_FLOAT_TYPE v);
 
   /**
+  @brief Set a group of properties for a junction node.
+  @param index The index of a junction node.
+  @param elev The junction's elevation.
+  @param dmnd The junction's primary base demand.
+  @param dmndpat The name of the demand's time pattern ("" for no pattern)
+  @return Error code.
+  */
+  int  DLLEXPORT ENsetjuncdata(int index, EN_API_FLOAT_TYPE elev,
+                 EN_API_FLOAT_TYPE dmnd, char *dmndpat);
+
+  /**
+  @brief Set a group of properties for a tank node.
+  @param index The index of a tank node.
+  @param elev The tank's bottom elevation.
+  @param initlvl The initial water level in the tank.
+  @param minlvl The minimum water level for the tank.
+  @param maxlvl The maximum water level for the tank.
+  @param diam The tank's diameter (0 if volume curve used).
+  @param minvol The volume of the tank at its minimum water level.
+  @param volcurve The name of the tank's volume curve ("" for no curve)
+  @return Error code.
+  */
+  int  DLLEXPORT ENsettankdata(int index, EN_API_FLOAT_TYPE elev,
+                 EN_API_FLOAT_TYPE initlvl, EN_API_FLOAT_TYPE minlvl,
+                 EN_API_FLOAT_TYPE maxlvl, EN_API_FLOAT_TYPE diam,
+                 EN_API_FLOAT_TYPE minvol, char *volcurve);
+
+  /**
   @brief Get coordinates (x,y) for a node.
   @param index The index of a node (first node is index 1).
   @param[out] x X-value of node's coordinate
@@ -742,6 +764,20 @@ extern "C" {
   @see EN_LinkProperty
   */
   int  DLLEXPORT ENsetlinkvalue(int index, int code, EN_API_FLOAT_TYPE v);
+
+  /**
+  @brief Set a collection of property values for a pipe link.
+  @param index The index of a pipe link.
+  @param length The pipe's length.
+  @param diam The pipe's diameter.
+  @param rough The pipe's roughness coefficient.
+  @param mloss The pipe's minor loss coefficient.
+  @return Error code.
+  */
+  int DLLEXPORT ENsetpipedata(int index, EN_API_FLOAT_TYPE length,
+                EN_API_FLOAT_TYPE diam, EN_API_FLOAT_TYPE rough,
+                EN_API_FLOAT_TYPE mloss);
+
 
 /********************************************************************
 

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -4,7 +4,7 @@
 'Declarations of functions in the EPANET PROGRAMMERs TOOLKIT
 '(EPANET2.DLL) for use with VB.Net.
 
-'Last updated on 7/19/15 - LR
+'Last updated on 01/01/2019
 
 Imports System.Runtime.InteropServices
 Imports System.Text
@@ -55,15 +55,16 @@ Public Const EN_HEADLOSS = 10
 Public Const EN_STATUS = 11
 Public Const EN_SETTING = 12
 Public Const EN_ENERGY = 13
-Public Const EN_LINKQUAL = 14   'ES
+Public Const EN_LINKQUAL = 14
 Public Const EN_LINKPATTERN = 15
-Public Const EN_EFFICIENCY = 16
-Public Const EN_HEADCURVE = 17
-Public Const EN_EFFICIENCYCURVE = 18
-Public Const EN_PRICEPATTERN = 19
-Public Const EN_STATE = 20
-Public Const EN_CONST_POWER = 21
-Public Const EN_SPEED = 22
+
+Public Const EN_PUMP_STATE = 16
+Public Const EN_PUMP_EFFIC = 17
+Public Const EN_PUMP_POWER = 18
+Public Const EN_PUMP_HCURVE = 19
+Public Const EN_PUMP_ECURVE = 20
+Public Const EN_PUMP_ECOST = 21
+Public Const EN_PUMP_EPAT = 22
 
 Public Const EN_DURATION = 0      ' Time parameters
 Public Const EN_HYDSTEP = 1
@@ -75,7 +76,7 @@ Public Const EN_REPORTSTART = 6
 Public Const EN_RULESTEP = 7
 Public Const EN_STATISTIC = 8
 Public Const EN_PERIODS = 9
-Public Const EN_STARTTIME = 10    'ES
+Public Const EN_STARTTIME = 10
 Public Const EN_HTIME = 11
 Public Const EN_QTIME = 12
 Public Const EN_HALTFLAG = 13
@@ -119,7 +120,7 @@ Public Const EN_MASS = 1
 Public Const EN_SETPOINT = 2
 Public Const EN_FLOWPACED = 3
 
-Public Const EN_HW = 0            ' Head loss formula
+Public Const EN_HW = 0            ' Head loss formulas
 Public Const EN_DW = 1
 Public Const EN_CM = 2
 
@@ -137,7 +138,7 @@ Public Const EN_CMD = 9
 Public Const EN_DDA = 0           ' Demand driven analysis
 Public Const EN_PDA = 1           ' Pressure driven analysis
 
-Public Const EN_TRIALS = 0       ' Misc. options
+Public Const EN_TRIALS = 0        ' Hydraulic options
 Public Const EN_ACCURACY = 1
 Public Const EN_TOLERANCE = 2
 Public Const EN_EMITEXPON = 3
@@ -146,38 +147,81 @@ Public Const EN_HEADERROR = 5
 Public Const EN_FLOWCHANGE = 6
 Public Const EN_DEMANDDEFPAT = 7
 Public Const EN_HEADLOSSFORM = 8
+Public Const EN_GLOBALEFFIC = 9
+Public Const EN_GLOBALPRICE = 10
+Public Const EN_GLOBALPATTERN = 11
+Public Const EN_DEMANDCHARGE = 12
 
-Public Const EN_LOWLEVEL = 0     ' Control types
+Public Const EN_LOWLEVEL = 0      ' Control types
 Public Const EN_HILEVEL = 1
 Public Const EN_TIMER = 2
 Public Const EN_TIMEOFDAY = 3
 
-Public Const EN_AVERAGE = 1      'Time statistic types
+Public Const EN_AVERAGE = 1       ' Time statistic types
 Public Const EN_MINIMUM = 2
 Public Const EN_MAXIMUM = 3
 Public Const EN_RANGE = 4
 
-Public Const EN_MIX1 = 0         'Tank mixing models
+Public Const EN_MIX1 = 0          ' Tank mixing models
 Public Const EN_MIX2 = 1
 Public Const EN_FIFO = 2
 Public Const EN_LIFO = 3
 
-Public Const EN_NOSAVE = 0       ' Save-results-to-file flag
+Public Const EN_NOSAVE = 0        ' Save-results-to-file flag
 Public Const EN_SAVE = 1
-Public Const EN_INITFLOW = 10    ' Re-initialize flow flag
+Public Const EN_INITFLOW = 10     ' Re-initialize flow flag
+Public Const EN_SAVE_AND_INIT = 11
 
-Public Const EN_CONST_HP = 0      ' constant horsepower
-Public Const EN_POWER_FUNC = 1    ' power function
-Public Const EN_CUSTOM = 2        ' user-defined custom curve
+Public Const EN_CONST_HP = 0      ' Constant horsepower pump curve
+Public Const EN_POWER_FUNC = 1    ' Power function pump curve
+Public Const EN_CUSTOM = 2        ' User-defined custom pump curve
+Public Const EN_NOCURVE = 3       ' No pump curve
 
-Public Const EN_V_CURVE = 0       ' volume curve
-Public Const EN_P_CURVE = 1       ' pump curve
-Public Const EN_E_CURVE = 2       ' efficiency curve
-Public Const EN_H_CURVE = 3       ' head loss curve
-Public Const EN_G_CURVE = 4       ' General\default curve
+Public Const EN_VOLUME_CURVE = 0  ' Volume curve
+Public Const EN_PUMP_CURVE = 1    ' Pump curve
+Public Const EN_EFFIC_CURVE = 2   ' Efficiency curve
+Public Const EN_HLOSS_CURVE = 3   ' Head loss curve
+Public Const EN_GENERIC_CURVE = 4 ' Generic curve
 
 Public Const EN_UNCONDITIONAL = 0 ' Unconditional object deletion
 Public Const EN_CONDITIONAL   = 1 ' Conditional object deletion
+
+Public Const EN_NO_REPORT = 0     ' No status report
+Public Const EN_NORMAL_REPORT = 1 ' Normal status report
+Public Const EN_FULL_REPORT = 2   ' Full status report
+
+Public Const EN_R_NODE   = 6      ' Rule objects
+Public Const EN_R_LINK   = 7
+Public Const EN_R_SYSTEM = 8
+
+Public Const EN_R_DEMAND    = 0   ' Rule variables
+Public Const EN_R_HEAD      = 1
+Public Const EN_R_GRADE     = 2
+Public Const EN_R_LEVEL     = 3
+Public Const EN_R_PRESSURE  = 4
+Public Const EN_R_FLOW      = 5
+Public Const EN_R_STATUS    = 6
+Public Const EN_R_SETTING   = 7
+Public Const EN_R_POWER     = 8
+Public Const EN_R_TIME      = 9
+Public Const EN_R_CLOCKTIME = 10
+Public Const EN_R_FILLTIME  = 11
+Public Const EN_R_DRAINTIME = 12
+
+Public Const EN_R_EQ    = 0       ' Rule operators
+Public Const EN_R_NE    = 1
+Public Const EN_R_LE    = 2
+Public Const EN_R_GE    = 3
+Public Const EN_R_LT    = 4
+Public Const EN_R_GT    = 5
+Public Const EN_R_IS    = 6
+Public Const EN_R_NOT   = 7
+Public Const EN_R_BELOW = 8
+Public Const EN_R_ABOVE = 9
+
+Public Const EN_R_IS_OPEN   = 1   ' Rule status types
+Public Const EN_R_IS_CLOSED = 2
+Public Const EN_R_IS_ACTIVE = 3
 
 'These are the external functions that comprise the DLL
 
@@ -239,6 +283,8 @@ Public Const EN_CONDITIONAL   = 1 ' Conditional object deletion
  Declare Function ENgetnodetype Lib "epanet2.dll" (ByVal Index As Int32, ByRef Code As Int32) As Int32
  Declare Function ENgetnodevalue Lib "epanet2.dll" (ByVal Index As Int32, ByVal Code As Int32, ByRef Value As Single) As Int32
  Declare Function ENsetnodevalue Lib "epanet2.dll" (ByVal Index As Int32, ByVal Code As Int32, ByVal Value As Single) As Int32
+ Declare Function ENsetjuncdata Lib "epanet2.dll" (ByVal index As Int32, ByVal elev As Single, ByVal dmnd As Single, ByVal dmndpat As String) As Int32
+ Declare Function ENsettankdata Lib "epanet2.dll" (ByVal index As Int32, ByVal elev As Single, ByVal initlvl As Single, ByVal minlvl As Single, ByVal maxlvl As Single, ByVal diam As Single, ByVal minvol As Single, ByVal volcurve As String) As Int32
  Declare Function ENgetcoord Lib "epanet2.dll" (ByVal Index As Int32, ByRef X As Single, ByRef Y As Single) As Int32
  Declare Function ENsetcoord Lib "epanet2.dll" (ByVal Index As Int32, ByVal X As Single, ByVal Y As Single) As Int32
 
@@ -265,6 +311,7 @@ Public Const EN_CONDITIONAL   = 1 ' Conditional object deletion
  Declare Function ENsetlinknodes Lib "epanet2.dll" (ByVal index As Int32, ByVal node1 As Int32, ByVal node2 As Int32) As Int32
  Declare Function ENgetlinkvalue Lib "epanet2.dll" (ByVal Index As Int32, ByVal Code As Int32, ByRef Value As Single) As Int32
  Declare Function ENsetlinkvalue Lib "epanet2.dll" (ByVal Index As Int32, ByVal Code As Int32, ByVal Value As Single) As Int32
+ Declare Function ENsetpipedata Lib "epanet2.dll" (ByVal index As Int32, ByVal length As Single, ByVal diam As Single, ByVal rough As Single, ByVal mloss As Single) As Int32
  
 'Pump Functions
  Declare Function ENgetheadcurveindex Lib "epanet2.dll" (ByVal Index As Int32, ByVal CurveIndex As int32) As Int32  'ES

--- a/include/epanet2_2.h
+++ b/include/epanet2_2.h
@@ -11,7 +11,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/29/2018
+ Last Updated: 12/31/2018
  ******************************************************************************
  */
 
@@ -46,21 +46,13 @@
       #endif // __cplusplus
     #elif defined(CYGWIN)
       #define DLLEXPORT __stdcall
-    #elif defined(__APPLE__)
-      #ifdef __cplusplus
-        #define DLLEXPORT
-      #else
-        #define DLLEXPORT
-      #endif
     #else
       #define DLLEXPORT
     #endif
   #endif
 #endif
 
-
 #include "epanet2_enums.h"
-
 
 // --- Declare the EPANET toolkit functions
 #if defined(__cplusplus)
@@ -137,6 +129,12 @@ typedef struct Project *EN_Project;
   int DLLEXPORT EN_getnodetype(EN_Project ph, int index, int *code);
   int DLLEXPORT EN_getnodevalue(EN_Project ph, int index, int code, EN_API_FLOAT_TYPE *value);
   int DLLEXPORT EN_setnodevalue(EN_Project ph, int index, int code, EN_API_FLOAT_TYPE v);
+  int DLLEXPORT EN_setjuncdata(EN_Project ph, int index, EN_API_FLOAT_TYPE elev,
+                EN_API_FLOAT_TYPE dmnd, char *dmndpat);
+  int DLLEXPORT EN_settankdata(EN_Project ph, int index, EN_API_FLOAT_TYPE elev,
+                EN_API_FLOAT_TYPE initlvl, EN_API_FLOAT_TYPE minlvl,
+                EN_API_FLOAT_TYPE maxlvl,  EN_API_FLOAT_TYPE diam,
+                EN_API_FLOAT_TYPE minvol, char *volcurve);
   int DLLEXPORT EN_getcoord(EN_Project ph, int index, EN_API_FLOAT_TYPE *x,
                 EN_API_FLOAT_TYPE *y);
   int DLLEXPORT EN_setcoord(EN_Project ph, int index, EN_API_FLOAT_TYPE x,
@@ -173,6 +171,9 @@ typedef struct Project *EN_Project;
   int DLLEXPORT EN_getlinkvalue(EN_Project ph, int index, EN_LinkProperty code,
                 EN_API_FLOAT_TYPE *value);
   int DLLEXPORT EN_setlinkvalue(EN_Project ph, int index, int code, EN_API_FLOAT_TYPE v);
+  int DLLEXPORT EN_setpipedata(EN_Project ph, int index, EN_API_FLOAT_TYPE length,
+                EN_API_FLOAT_TYPE diam, EN_API_FLOAT_TYPE rough, EN_API_FLOAT_TYPE mloss);
+
 
   int DLLEXPORT EN_getpumptype(EN_Project ph, int linkIndex, int *outType);
   int DLLEXPORT EN_getheadcurveindex(EN_Project ph, int pumpIndex, int *curveIndex);

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/29/2018
+ Last Updated: 01/01/2019
  ******************************************************************************
 */
 
@@ -69,13 +69,14 @@ typedef enum {
   EN_ENERGY       = 13, //!> Current pump energy usage
   EN_LINKQUAL     = 14, //!> Current link quality
   EN_LINKPATTERN  = 15, //!> Pump speed time pattern
-  EN_EFFICIENCY   = 16, //!> Current pump efficiency
-  EN_HEADCURVE    = 17, //!> Pump head v. flow curve
-  EN_EFFICIENCYCURVE = 18, //!> Pump efficiency v. flow curve
-  EN_PRICEPATTERN = 19,    //!> Pump energy price time pattern
-  EN_STATE        = 20,    //!> Current pump status
-  EN_CONST_POWER  = 21,    //!> Horsepower of constant horsepower pump
-  EN_SPEED        = 22     //!> Current pump speed setting
+
+  EN_PUMP_STATE   = 16, //!> Current pump status
+  EN_PUMP_EFFIC   = 17, //!> Current pump efficiency
+  EN_PUMP_POWER   = 18, //!> Pump constant power rating
+  EN_PUMP_HCURVE  = 19, //!> Pump head v. flow curve
+  EN_PUMP_ECURVE  = 20, //!> Pump efficiency v. flow curve
+  EN_PUMP_ECOST   = 21, //!> Pump average energy price
+  EN_PUMP_EPAT    = 22  //!> Pump energy price time pattern
 } EN_LinkProperty;
 
 /// Time parameter codes
@@ -181,17 +182,21 @@ typedef enum {
   EN_PDA         = 1    //!< Pressure driven analysis
 } EN_DemandModel;
 
-/// Simulation Option codes
+/// Simulation option codes
 typedef enum {
-  EN_TRIALS       = 0,  //!> Maximum hydraulic trials allowed
-  EN_ACCURACY     = 1,  //!> Hydraulic convergence accuracy
-  EN_TOLERANCE    = 2,  //!> Water quality tolerance
-  EN_EMITEXPON    = 3,  //!> Exponent for emitter head loss formula
-  EN_DEMANDMULT   = 4,  //!> Global demand multiplier
-  EN_HEADERROR    = 5,  //!> Maximum allowable head loss error
-  EN_FLOWCHANGE   = 6,  //!> Maximum allowable flow change
-  EN_DEMANDDEFPAT = 7,  //!> Default demand time pattern
-  EN_HEADLOSSFORM = 8   //!> Head loss formula code
+  EN_TRIALS         = 0,  //!> Maximum hydraulic trials allowed
+  EN_ACCURACY       = 1,  //!> Hydraulic convergence accuracy
+  EN_TOLERANCE      = 2,  //!> Water quality tolerance
+  EN_EMITEXPON      = 3,  //!> Exponent for emitter head loss formula
+  EN_DEMANDMULT     = 4,  //!> Global demand multiplier
+  EN_HEADERROR      = 5,  //!> Maximum allowable head loss error
+  EN_FLOWCHANGE     = 6,  //!> Maximum allowable flow change
+  EN_DEFDEMANDPAT   = 7,  //!> Default demand time pattern
+  EN_HEADLOSSFORM   = 8,  //!> Head loss formula code
+  EN_GLOBALEFFIC    = 9,  //!> Global pump efficiency
+  EN_GLOBALPRICE    = 10, //!> Global energy price per KWH
+  EN_GLOBALPATTERN  = 11, //!> Global energy price pattern
+  EN_DEMANDCHARGE   = 12  //!> Energy charge per max. KW usage
 } EN_Option;
 
 /// Simple control types
@@ -236,18 +241,25 @@ typedef enum {
 
 /// Data curve types
 typedef enum {
-  EN_V_CURVE     = 0,   //!< Tank volume curve
-  EN_P_CURVE     = 1,   //!< Pump characteristic curve
-  EN_E_CURVE     = 2,   //!< Pump efficiency curve
-  EN_H_CURVE     = 3,   //!< Valve head loss curve
-  EN_G_CURVE     = 4    //!< General\default curve
+  EN_VOLUME_CURVE  = 0,   //!< Tank volume curve
+  EN_PUMP_CURVE    = 1,   //!< Pump head curve
+  EN_EFFIC_CURVE   = 2,   //!< Pump efficiency curve
+  EN_HLOSS_CURVE   = 3,   //!< Valve head loss curve
+  EN_GENERIC_CURVE = 4    //!< Generic curve
 } EN_CurveType;
 
-/// Deletion action types
+/// Deletion action codes
 typedef enum {
   EN_UNCONDITIONAL = 0, //!> Delete all controls that contain object
   EN_CONDITIONAL   = 1  //!> Cancel object deletion if contained in controls
 } EN_ActionCodeType;
+
+/// Status report options
+typedef enum {
+  EN_NO_REPORT = 0,
+  EN_NORMAL_REPORT = 1,
+  EN_FULL_REPORT = 2
+} EN_StatusReport;
 
 /// Rule object codes
 typedef enum {
@@ -293,13 +305,6 @@ typedef enum {
   EN_R_IS_CLOSED = 2,
   EN_R_IS_ACTIVE = 3
 } EN_RuleStatus;
-
-/// Status report types
-typedef enum {
-  EN_NO_REPORT     = 0,
-  EN_NORMAL_REPORT = 1,
-  EN_FULL_REPORT   = 2
-} EN_StatusReport;
 
 
 #endif //EPANET2_ENUMS_H

--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -288,6 +288,20 @@ int DLLEXPORT ENsetnodevalue(int index, int code, EN_API_FLOAT_TYPE v)
     return EN_setnodevalue(_defaultProject, index, code, v);
 }
 
+int DLLEXPORT ENsetjuncdata(int index, EN_API_FLOAT_TYPE elev, EN_API_FLOAT_TYPE dmnd,
+              char *dmndpat)
+{
+    return EN_setjuncdata(_defaultProject, index, elev, dmnd, dmndpat);
+}
+
+int  DLLEXPORT ENsettankdata(int index, EN_API_FLOAT_TYPE elev, EN_API_FLOAT_TYPE initlvl,
+               EN_API_FLOAT_TYPE minlvl, EN_API_FLOAT_TYPE maxlvl, EN_API_FLOAT_TYPE diam,
+               EN_API_FLOAT_TYPE minvol, char *volcurve)
+{
+    return EN_settankdata(_defaultProject, index, elev, initlvl, minlvl, maxlvl,
+                          diam, minvol, volcurve);
+}
+
 int DLLEXPORT ENgetcoord(int index, EN_API_FLOAT_TYPE *x, EN_API_FLOAT_TYPE *y)
 {
     return EN_getcoord(_defaultProject, index, x, y);
@@ -411,6 +425,13 @@ int DLLEXPORT ENsetlinkvalue(int index, int code, EN_API_FLOAT_TYPE v)
 {
     return EN_setlinkvalue(_defaultProject, index, code, v);
 }
+
+int DLLEXPORT ENsetpipedata(int index, EN_API_FLOAT_TYPE length, EN_API_FLOAT_TYPE diam,
+              EN_API_FLOAT_TYPE rough, EN_API_FLOAT_TYPE mloss)
+{
+    return EN_setpipedata(_defaultProject, index, length, diam, rough, mloss);
+}
+
 
 /********************************************************************
 

--- a/src/input2.c
+++ b/src/input2.c
@@ -7,7 +7,7 @@ Description:  reads and interprets network data from an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 12/15/2018
+Last Updated: 01/01/2019
 ******************************************************************************
 */
 
@@ -381,7 +381,7 @@ int updatepumpparams(Project *pr, int pumpindex)
         curveindex = pump->Hcurve;
         if (curveindex == 0) return 226;
         curve = &net->Curve[curveindex];
-        curve->Type = P_CURVE;
+        curve->Type = PUMP_CURVE;
         npts = curve->Npts;
 
         // Generic power function curve 

--- a/src/input3.c
+++ b/src/input3.c
@@ -7,7 +7,7 @@ Description:  parses network data from a line of an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 12/15/2018
+Last Updated: 01/01/2019
 ******************************************************************************
 */
 
@@ -205,7 +205,7 @@ int tankdata(Project *pr)
             tmplist = getlistitem(parser->Tok[7], parser->Curvelist);
             if (tmplist == NULL) return setError(parser, 7, 206);
             curve = tmplist->i;
-            net->Curve[curve].Type = V_CURVE;
+            net->Curve[curve].Type = VOLUME_CURVE;
         }
         if (initlevel < 0.0) return setError(parser, 2, 209);
         if (minlevel  < 0.0) return setError(parser, 3, 209);
@@ -508,7 +508,7 @@ int valvedata(Project *pr)
         tmplist = getlistitem(parser->Tok[5], parser->Curvelist);
         if (tmplist == NULL) return setError(parser, 5, 206);
         setting = tmplist->i;
-        net->Curve[tmplist->i].Type = H_CURVE;
+        net->Curve[tmplist->i].Type = HLOSS_CURVE;
         status = OPEN;
     }
     else if (!getfloat(parser->Tok[5], &setting)) return setError(parser, 5, 202);
@@ -1391,7 +1391,7 @@ int energydata(Project *pr)
             listitem = getlistitem(parser->Tok[n - 1], parser->Curvelist);
             if (listitem == NULL) return setError(parser, n - 1, 206); 
             Pump[j].Ecurve = listitem->i;
-            net->Curve[listitem->i].Type = E_CURVE;
+            net->Curve[listitem->i].Type = EFFIC_CURVE;
         }
         return 0;
     }

--- a/src/project.c
+++ b/src/project.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 12/15/2018
+ Last Updated: 01/01/2019
  ******************************************************************************
 */
 
@@ -354,7 +354,7 @@ int allocdata(Project *pr)
         for (n = 0; n <= pr->parser.MaxCurves; n++)
         {
             pr->network.Curve[n].Npts = 0;
-            pr->network.Curve[n].Type = G_CURVE;
+            pr->network.Curve[n].Type = GENERIC_CURVE;
             pr->network.Curve[n].X = NULL;
             pr->network.Curve[n].Y = NULL;
         }

--- a/src/types.h
+++ b/src/types.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 12/15/2018
+ Last Updated: 01/01/2019
  ******************************************************************************
 */
 
@@ -157,11 +157,11 @@ typedef enum {
 } QualType;
 
 typedef enum {
-  V_CURVE,       // volume curve
-  P_CURVE,       // pump curve
-  E_CURVE,       // efficiency curve
-  H_CURVE,       // head loss curve
-  G_CURVE        // general\default curve
+  VOLUME_CURVE,  // volume curve
+  PUMP_CURVE,    // pump curve
+  EFFIC_CURVE,   // efficiency curve
+  HLOSS_CURVE,   // head loss curve
+  GENERIC_CURVE  // generic curve
 } CurveType;
 
 typedef enum {

--- a/tests/test_net_builder.cpp
+++ b/tests/test_net_builder.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(test_net_builder)
     BOOST_REQUIRE(error == 0);
     error = EN_setpattern(ph, 1, P, 12);
     BOOST_REQUIRE(error == 0);
-    error = EN_setoption(ph, EN_DEMANDDEFPAT, 1);
+    error = EN_setoption(ph, EN_DEFDEMANDPAT, 1);
     BOOST_REQUIRE(error == 0);
     for (i = 0; i < 9; i++)
     {

--- a/tests/test_net_builder_2.cpp
+++ b/tests/test_net_builder_2.cpp
@@ -1,0 +1,114 @@
+// Test of EPANET's Network Building Functions
+//
+// This is a test of the API functions EN_setjuncdata, EN_settankdata & EN_setpipedata
+//
+#define _CRT_SECURE_NO_DEPRECATE
+
+//#define NO_BOOST
+
+#ifndef NO_BOOST
+#define BOOST_TEST_MODULE "toolkit"
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <iostream>
+#include <string>
+#include "epanet2_2.h"
+
+#define DATA_PATH_INP "./net1.inp"
+#define DATA_PATH_RPT "./test.rpt"
+#define DATA_PATH_OUT "./test.out"
+
+#ifdef NO_BOOST
+#define BOOST_REQUIRE(x) (((x)) ? cout << "\nPassed at line " << __LINE__ : cout << "\nFailed at line " << __LINE__ )
+#endif
+
+using namespace std;
+
+#ifndef NO_BOOST
+BOOST_AUTO_TEST_SUITE (test_toolkit)
+BOOST_AUTO_TEST_CASE(test_setlinktype)
+{
+#else
+int main(int argc, char *argv[])
+{
+#endif
+
+    int index;
+    char id[EN_MAXID+1];
+    float p1_1, p2_1, p1_2, p2_2;
+    float q1_1, q2_1, q1_2, q2_2;
+
+    // Create & initialize a project
+    EN_Project ph = NULL;
+    EN_createproject(&ph);
+    EN_init(ph, "", "", EN_GPM, EN_HW);
+    
+    // Build a network
+    EN_addnode(ph, "N1", EN_JUNCTION);
+    EN_addnode(ph, "N2", EN_JUNCTION);
+    EN_addnode(ph, "N3", EN_RESERVOIR);
+    EN_addnode(ph, "N4", EN_TANK);
+    EN_addlink(ph, "L1", EN_PUMP, "N3", "N1");
+    EN_addlink(ph, "L2", EN_PIPE, "N1", "N3");
+    EN_addlink(ph, "L3", EN_PIPE, "N1", "N2");
+    EN_addcurve(ph, "C1");
+
+    // Set network data using the new helper functions
+    EN_setcurvevalue(ph, 1, 1, 1500, 250);
+    EN_setjuncdata(ph, 1, 700, 500, "");
+    EN_setjuncdata(ph, 2, 710, 500, "");
+    EN_setnodevalue(ph, 3, EN_ELEVATION, 800);
+    EN_settankdata(ph, 4, 850, 120, 100, 150, 50.5, 0, "");
+    EN_setlinkvalue(ph, 1, EN_PUMP_HCURVE, 1);
+    EN_setpipedata(ph, 2, 10560, 12, 100, 0);
+    EN_setpipedata(ph, 3, 5280, 14, 100, 0);
+
+    // Run hydraulics
+    EN_solveH(ph);
+
+    // Save results
+    EN_getnodevalue(ph, 1, EN_PRESSURE, &p1_1);
+    EN_getnodevalue(ph, 2, EN_PRESSURE, &p2_1);
+    EN_getlinkvalue(ph, 1, EN_FLOW, &q1_1);
+    EN_getlinkvalue(ph, 2, EN_FLOW, &q2_1);
+
+    // Save project
+    EN_saveinpfile(ph, "test2.inp");
+
+    // Close project
+    EN_close(ph);
+
+    // Open the saved project file
+    EN_open(ph, "test2.inp", "", "");
+
+    // Run hydraulics
+    EN_solveH(ph);
+
+    // Save these new results
+    EN_getnodevalue(ph, 1, EN_PRESSURE, &p1_2);
+    EN_getnodevalue(ph, 2, EN_PRESSURE, &p2_2);
+    EN_getlinkindex(ph, "L1", &index);
+    EN_getlinkvalue(ph, index, EN_FLOW, &q1_2);
+    EN_getlinkindex(ph, "L2", &index);
+    EN_getlinkvalue(ph, index, EN_FLOW, &q2_2);
+
+    // Display old & new results
+    cout << "\n  Node N1 Pressure: " << p1_1 << "  " << p1_2;
+    cout << "\n  Node N2 Pressure: " << p2_1 << "  " << p2_2;
+    cout << "\n  Link L1 Flow:     " << q1_1 << "  " << q1_2;
+    cout << "\n  Link L2 Flow:     " << q2_1 << "  " << q2_2;
+
+    // Compare old & new results
+    BOOST_REQUIRE(p1_1 == p1_2);
+    BOOST_REQUIRE(p2_1 == p2_2);
+    BOOST_REQUIRE(q1_1 == q1_2);
+    BOOST_REQUIRE(q2_1 == q2_2);
+
+    // Close project
+    EN_close(ph);
+    EN_deleteproject(&ph);
+}
+#ifndef NO_BOOST
+BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/win_build/WinSDK/epanet2.def
+++ b/win_build/WinSDK/epanet2.def
@@ -85,6 +85,7 @@ EXPORTS
     ENsetelseaction               = _ENsetelseaction@20
     ENsetflowunits                = _ENsetflowunits@4
     ENsetheadcurveindex           = _ENsetheadcurveindex@8
+    ENsetjuncdata                 = _ENsetjuncdata@16
     ENsetlinkid                   = _ENsetlinkid@8
     ENsetlinknodes                = _ENsetlinknodes@12
     ENsetlinktype                 = _ENsetlinktype@12
@@ -93,7 +94,8 @@ EXPORTS
     ENsetnodevalue                = _ENsetnodevalue@12                  
     ENsetoption                   = _ENsetoption@8                      
     ENsetpattern                  = _ENsetpattern@12                    
-    ENsetpatternvalue             = _ENsetpatternvalue@12               
+    ENsetpatternvalue             = _ENsetpatternvalue@12
+    ENsetpipedata                 = _ENsetpipedata@20
     ENsetpremise                  = _ENsetpremise@36
     ENsetpremiseindex             = _ENsetpremiseindex@12
     ENsetpremisestatus            = _ENsetpremisestatus@12
@@ -101,7 +103,8 @@ EXPORTS
     ENsetqualtype                 = _ENsetqualtype@16                   
     ENsetreport                   = _ENsetreport@4                      
     ENsetrulepriority             = _ENsetrulepriority@8
-    ENsetstatusreport             = _ENsetstatusreport@4                
+    ENsetstatusreport             = _ENsetstatusreport@4
+    ENsettankdata                 = _ENsettankdata@32
     ENsetthenaction               = _ENsetthenaction@20
     ENsettimeparam                = _ENsettimeparam@8                   
     ENsolveH                      = _ENsolveH@0                         


### PR DESCRIPTION
This commit adds the following network building features to the API:

1. Adds additional properties that can be set using` EN_setnodevalue`, `EN_setlinkvalue` and `EN_setoption` that now allows the API to build a complete EPANET network model from code.
2. Adds new functions` EN_setjuncdata`, `EN_settankdata`, and `EN_setpipedata` that allows one to set values for the multiple object properties with a single function call.
3. Adds a new unit test (`test_net_builder_2`) that tests these new functions.
4. Adds to the enumerated constant names in `epanet2_enums.h` and revises some v.2.2 names to make them more understandable.