### PR TITLE
Simplify command line arguments for reg test helper scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ init:
   - set EPANET_HOME=%APPVEYOR_BUILD_FOLDER%
   - set BUILD_HOME=buildprod
   - set TEST_HOME=nrtestsuite
-  - set NRTEST_SCRIPT=C:\Python27\Scripts
+
   # See values set
   - echo %APPVEYOR_BUILD_WORKER_IMAGE%
   - echo %BUILD_HOME%
@@ -67,7 +67,7 @@ test_script:
   - ctest -C Release
   # run regression tests
   - cd %EPANET_HOME%
-  - tools\run-nrtest.cmd %NRTEST_SCRIPT% %TEST_HOME% %APPVEYOR_REPO_COMMIT%
+  - tools\run-nrtest.cmd %APPVEYOR_REPO_COMMIT%
 
 after_test:
   # zip up the SUT benchmarks

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ build_script:
 
 before_test:
   - cd %EPANET_HOME%
-  - tools\before-test.cmd %TEST_HOME% %EPANET_HOME%\%BUILD_HOME%\bin\Release %APPVEYOR_REPO_COMMIT%
+  - tools\before-test.cmd %APPVEYOR_REPO_COMMIT%
 
 # run custom test script
 test_script:

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -12,7 +12,7 @@
 ::
 ::  Note:
 ::    Tests and benchmark files are stored in the epanet-example-networks repo.
-::    This script retreives them using a stable URL associated with a GitHub
+::    This script retrieves them using a stable URL associated with a GitHub
 ::    release and stages the files for nrtest to run. The script assumes that
 ::    before-test.cmd and gen-config.cmd are located together in the same folder.
 ::

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -7,9 +7,8 @@
 ::          US EPA - ORD/NRMRL
 ::
 ::  Arguments:
-::    1 - relative path regression test file staging location
-::    2 - absolute path to location of software under test
-::    3 - build identifier for software under test
+::    1 - build identifier for software under test
+::    2 - (relative path regression test file staging location)
 ::
 ::  Note:
 ::    Tests and benchmark files are stored in the epanet-example-networks repo.
@@ -21,12 +20,23 @@
 @echo off
 setlocal
 
-set SCRIPT_HOME=%~dp0
-set TEST_HOME=%~1
-
 
 set EXAMPLES_VER=1.0.2-dev.5
 set BENCHMARK_VER=220dev5
+
+set "SCRIPT_HOME=%~dp0"
+set "EXE_HOME=buildprod\bin\Release"
+
+:: Determine SUT executable path
+for %%a in ("%SCRIPT_HOME:~0,-1%") do set "SUT_PATH=%%~dpa"
+set SUT_PATH=%SUT_PATH%%EXE_HOME%
+
+:: Check existence and apply default arguments
+IF NOT [%1]==[] ( set "SUT_VER=%~1"
+) ELSE ( set "SUT_VER=vXXX" )
+
+IF NOT [%2]==[] ( set "TEST_HOME=%~2"
+) ELSE ( set "TEST_HOME=nrtestsuite" )
 
 
 set TESTFILES_URL=https://github.com/OpenWaterAnalytics/epanet-example-networks/archive/v%EXAMPLES_VER%.zip
@@ -59,4 +69,4 @@ mklink /D .\tests .\epanet-example-networks-%EXAMPLES_VER%\epanet-tests
 
 :: generate json configuration file for software under test
 mkdir apps
-%SCRIPT_HOME%\gen-config.cmd %~2 > apps\epanet-%~3.json
+%SCRIPT_HOME%\gen-config.cmd %SUT_PATH% > apps\epanet-%SUT_VER%.json

--- a/tools/before-test.cmd
+++ b/tools/before-test.cmd
@@ -12,8 +12,8 @@
 ::
 ::  Note:
 ::    Tests and benchmark files are stored in the epanet-example-networks repo.
-::    This script retreives them using a stable URL associated with a release on
-::    GitHub and stages the files for nrtest to run. The script assumes that
+::    This script retreives them using a stable URL associated with a GitHub
+::    release and stages the files for nrtest to run. The script assumes that
 ::    before-test.cmd and gen-config.cmd are located together in the same folder.
 ::
 

--- a/tools/run-nrtest.cmd
+++ b/tools/run-nrtest.cmd
@@ -7,24 +7,35 @@
 ::          US EPA - ORD/NRMRL
 ::
 ::  Arguments:
-::    1 - nrtest script path
-::    2 - test suite path
-::    3 - version/build identifier
+::    1 - version/build identifier
+::    2 - (test suite path)
 ::
 
 @echo off
 setlocal
 
-set NRTEST_SCRIPT_PATH=%~1
-set TEST_SUITE_PATH=%~2
 
 set BENCHMARK_VER=220dev5
 
 
+:: Determine location of python Scripts folder
+FOR /F "tokens=*" %%G IN ('where python') DO (
+  set PYTHON_DIR=%%~dpG
+)
+set "NRTEST_SCRIPT_PATH=%PYTHON_DIR%Scripts"
+
+:: Check existence and apply default arguments
+IF NOT [%1]==[] ( set "SUT_VER=%~1"
+) ELSE ( set "SUT_VER=vXXX" )
+
+IF NOT [%2]==[] ( set "TEST_SUITE_PATH=%~2"
+) ELSE ( set "TEST_SUITE_PATH=nrtestsuite" )
+
+
 set NRTEST_EXECUTE_CMD=python %NRTEST_SCRIPT_PATH%\nrtest execute
-set TEST_APP_PATH=apps\epanet-%3.json
+set TEST_APP_PATH=apps\epanet-%SUT_VER%.json
 set TESTS=tests\examples tests\exeter tests\large tests\network_one tests\press_depend tests\small tests\tanks tests\valves
-set TEST_OUTPUT_PATH=benchmark\epanet-%3
+set TEST_OUTPUT_PATH=benchmark\epanet-%SUT_VER%
 
 set NRTEST_COMPARE_CMD=python %NRTEST_SCRIPT_PATH%\nrtest compare
 set REF_OUTPUT_PATH=benchmark\epanet-%BENCHMARK_VER%


### PR DESCRIPTION
This PR simplifies the usage `before-test.cmd` and `run-nrtest.cmd` by introducing default arguments. The scripts can be called with no arguments and the tests will run. 