### PR TITLE
ENgetcoords and ENsetcoords fixes

### DIFF
--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -5,7 +5,7 @@ Attribute VB_Name = "Module1"
 'Declarations of functions in the EPANET PROGRAMMERs TOOLKIT
 '(EPANET2.DLL)
 
-'Last updated on 02/08/2019
+'Last updated on 02/28/2019
 
 ' These are codes used by the DLL functions
 Public Const EN_ELEVATION = 0     ' Node parameters
@@ -284,8 +284,8 @@ Public Const EN_R_IS_ACTIVE = 3
  Declare Function ENsetnodevalue Lib "epanet2.dll" (ByVal index As Long, ByVal property As Long, ByVal value As Single) As Long
  Declare Function ENsetjuncdata Lib "epanet2.dll" (ByVal index As Long, ByVal elev As Single, ByVal dmnd As Single, ByVal dmndpat As String) As Long
  Declare Function ENsettankdata Lib "epanet2.dll" (ByVal index As Long, ByVal elev As Single, ByVal initlvl As Single, ByVal minlvl As Single, ByVal maxlvl As Single, ByVal diam As Single, ByVal minvol As Single, ByVal volcurve As String) As Long
- Declare Function ENgetcoord Lib "epanet2.dll" (ByVal index As Long, x As Single, y As Single) As Long
- Declare Function ENsetcoord Lib "epanet2.dll" (ByVal index As Long, ByVal x As Single, ByVal y As Single) As Long
+ Declare Function ENgetcoord Lib "epanet2.dll" (ByVal index As Long, x As Double, y As Double) As Long
+ Declare Function ENsetcoord Lib "epanet2.dll" (ByVal index As Long, ByVal x As Double, ByVal y As Double) As Long
  
 'Nodal Demand Functions
  Declare Function ENgetdemandmodel Lib "epanet2.dll" (type_ As Long, pmin As Single, preq As Single, pexp As Single) As Long

--- a/include/epanet2.def
+++ b/include/epanet2.def
@@ -13,10 +13,8 @@ EXPORTS
     ENcloseQ                      = _ENcloseQ@0
     ENcopyreport                  = _ENcopyreport@4
     ENdeletecontrol               = _ENdeletecontrol@4
-    ENdeletecurve                 = _ENdeletecurve@4
     ENdeletelink                  = _ENdeletelink@8
     ENdeletenode                  = _ENdeletenode@8
-    ENdeletepattern               = _ENdeletepattern@4
     ENdeleterule                  = _ENdeleterule@4
     ENepanet                      = _ENepanet@16
     ENgetaveragepatternvalue      = _ENgetaveragepatternvalue@8
@@ -61,7 +59,7 @@ EXPORTS
     ENgetruleID                   = _ENgetruleID@8
     ENgetstatistic                = _ENgetstatistic@8
     ENgetthenaction               = _ENgetthenaction@20
-    ENgettimeparam                = _ENgettimeparam@8
+    ENgettimeparam                = _ENgettimeparam@8                   
     ENgettitle                    = _ENgettitle@12    
     ENgetversion                  = _ENgetversion@4
     ENinit                        = _ENinit@16
@@ -81,9 +79,8 @@ EXPORTS
     ENsaveinpfile                 = _ENsaveinpfile@4                    
     ENsetbasedemand               = _ENsetbasedemand@12
     ENsetcontrol                  = _ENsetcontrol@24                    
-    ENsetcoord                    = _ENsetcoord@12
-    ENsetcurve                    = _ENsetcurve@16
-    ENsetcurveid                  = _ENsetcurveid@8    
+    ENsetcoord                    = _ENsetcoord@20
+    ENsetcurve                    = _ENsetcurve@16                    
     ENsetcurvevalue               = _ENsetcurvevalue@16               
     ENsetdemandmodel              = _ENsetdemandmodel@16
     ENsetdemandname               = _ENsetdemandname@12
@@ -99,8 +96,7 @@ EXPORTS
     ENsetnodeid                   = _ENsetnodeid@8                  
     ENsetnodevalue                = _ENsetnodevalue@12                  
     ENsetoption                   = _ENsetoption@8                      
-    ENsetpattern                  = _ENsetpattern@12
-    ENsetpatternid                = _ENsetpatternid@8    
+    ENsetpattern                  = _ENsetpattern@12                    
     ENsetpatternvalue             = _ENsetpatternvalue@12
     ENsetpipedata                 = _ENsetpipedata@20
     ENsetpremise                  = _ENsetpremise@36
@@ -113,10 +109,12 @@ EXPORTS
     ENsetstatusreport             = _ENsetstatusreport@4
     ENsettankdata                 = _ENsettankdata@32
     ENsetthenaction               = _ENsetthenaction@20
-    ENsettimeparam                = _ENsettimeparam@8
+    ENsettimeparam                = _ENsettimeparam@8                   
     ENsettitle                    = _ENsettitle@12    
     ENsolveH                      = _ENsolveH@0                         
     ENsolveQ                      = _ENsolveQ@0                         
     ENstepQ                       = _ENstepQ@4
     ENusehydfile                  = _ENusehydfile@4
     ENwriteline                   = _ENwriteline@4
+    ENgettitle                    = _ENgettitle@12
+    ENsettitle                    = _ENsettitle@12

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 02/28/2019
  ******************************************************************************
  */
 
@@ -210,9 +210,9 @@ extern "C" {
                  EN_API_FLOAT_TYPE maxlvl, EN_API_FLOAT_TYPE diam,
                  EN_API_FLOAT_TYPE minvol, char *volcurve);
 
-  int  DLLEXPORT ENgetcoord(int index, EN_API_FLOAT_TYPE *x, EN_API_FLOAT_TYPE *y);
+  int  DLLEXPORT ENgetcoord(int index, double *x, double *y);
 
-  int  DLLEXPORT ENsetcoord(int index, EN_API_FLOAT_TYPE x, EN_API_FLOAT_TYPE y);
+  int  DLLEXPORT ENsetcoord(int index, double x, double y);
 
 /********************************************************************
 
@@ -403,9 +403,8 @@ extern "C" {
 
   int DLLEXPORT ENsetelseaction(int ruleIndex, int actionIndex, int linkIndex,
                 int status, EN_API_FLOAT_TYPE setting);
-
+  
   int DLLEXPORT ENsetrulepriority(int index, EN_API_FLOAT_TYPE priority);
-
 
   #if defined(__cplusplus)
   }

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -4,7 +4,7 @@
 'Declarations of functions in the EPANET PROGRAMMERs TOOLKIT
 '(EPANET2.DLL) for use with VB.Net.
 
-'Last updated on 02/08/2019
+'Last updated on 02/28/2019
 
 Imports System.Runtime.InteropServices
 Imports System.Text
@@ -289,8 +289,8 @@ Public Const EN_R_IS_ACTIVE = 3
  Declare Function ENsetnodevalue Lib "epanet2.dll" (ByVal index As Int32, ByVal property As Int32, ByVal value As Single) As Int32
  Declare Function ENsetjuncdata Lib "epanet2.dll" (ByVal index As Int32, ByVal elev As Single, ByVal dmnd As Single, ByVal dmndpat As String) As Int32
  Declare Function ENsettankdata Lib "epanet2.dll" (ByVal index As Int32, ByVal elev As Single, ByVal initlvl As Single, ByVal minlvl As Single, ByVal maxlvl As Single, ByVal diam As Single, ByVal minvol As Single, ByVal volcurve As String) As Int32
- Declare Function ENgetcoord Lib "epanet2.dll" (ByVal index As Int32, x As Single, y As Single) As Int32
- Declare Function ENsetcoord Lib "epanet2.dll" (ByVal index As Int32, ByVal x As Single, ByVal y As Single) As Int32
+ Declare Function ENgetcoord Lib "epanet2.dll" (ByVal index As Int32, x As Double, y As Double) As Int32
+ Declare Function ENsetcoord Lib "epanet2.dll" (ByVal index As Int32, ByVal x As Double, ByVal y As Double) As Int32
  
 'Nodal Demand Functions
  Declare Function ENgetdemandmodel Lib "epanet2.dll" (type_ As Int32, pmin As Single, preq As Single, pexp As Single) As Int32

--- a/include/epanet2_2.h
+++ b/include/epanet2_2.h
@@ -713,6 +713,9 @@ typedef struct Project *EN_Project;
   @param traceNode the ID name of the node being traced if `qualType = EN_TRACE`.
   @return an error code.
 
+  The type of water quality analysis cannot be changed from EN_NONE while the
+  quality solver is still open. 
+  
   Chemical name and units can be an empty string if the analysis is not for a chemical.
   The same holds for the trace node if the analysis is not for source tracing.
 

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -218,6 +218,7 @@ int DLLEXPORT EN_open(EN_Project p, const char *inpFile, const char *rptFile,
 
   // Read input data
   ERRCODE(getdata(p));
+  fclose(p->parser.InFile);
 
   // Free temporary linked lists used for Patterns & Curves
   freeTmplist(p->parser.Patlist);

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 02/28/2019
  ******************************************************************************
 */
 
@@ -1566,6 +1566,11 @@ int DLLEXPORT EN_setqualtype(EN_Project p, int qualType, char *chemName,
 
     if (!p->Openflag) return 102;
     if (qualType < EN_NONE || qualType > EN_TRACE) return 251;
+    
+    // Cannot change quality choice if solver currently open under the no
+    // quality option since required memory was not allocated
+    if (qual->OpenQflag && qual->Qualflag == NONE) return 262;
+
     qual->Qualflag = (char)qualType;
     qual->Ctol *= Ucf[QUALITY];
     if (qual->Qualflag == CHEM) // Chemical analysis

--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 02/28/2019
  ******************************************************************************
 */
 #ifndef __APPLE__
@@ -340,16 +340,12 @@ int  DLLEXPORT ENsettankdata(int index, EN_API_FLOAT_TYPE elev,
                           diam, minvol, volcurve);
 }
 
-int DLLEXPORT ENgetcoord(int index, EN_API_FLOAT_TYPE *x, EN_API_FLOAT_TYPE *y)
+int DLLEXPORT ENgetcoord(int index, double *x, double *y)
 {
-    double xx = 0.0, yy = 0.0;
-    int errcode = EN_getcoord(_defaultProject, index, &xx, &yy);
-    *x = (EN_API_FLOAT_TYPE)xx;
-    *y = (EN_API_FLOAT_TYPE)yy;
-    return errcode; 
+    return EN_getcoord(_defaultProject, index, x, y);
 }
 
-int DLLEXPORT ENsetcoord(int index, EN_API_FLOAT_TYPE x, EN_API_FLOAT_TYPE y)
+int DLLEXPORT ENsetcoord(int index, double x, double y)
 {
     return EN_setcoord(_defaultProject, index, x, y);
 }

--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -7,7 +7,7 @@ Description:  saves network data to an EPANET formatted text file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 02/28/2019
 ******************************************************************************
 */
 
@@ -52,8 +52,8 @@ void saveauxdata(Parser *parser, FILE *f)
     FILE *InFile = parser->InFile;
   
     sect = -1;
+    InFile = fopen(parser->InpFname, "rt");
     if (InFile == NULL) return;
-    rewind(InFile);
     while (fgets(line, MAXLINE, InFile) != NULL)
     {
         strcpy(s, line);
@@ -84,6 +84,7 @@ void saveauxdata(Parser *parser, FILE *f)
               break;
         }
     }
+    fclose(InFile);
 }
 
 int saveinpfile(Project *pr, const char *fname)

--- a/src/output.c
+++ b/src/output.c
@@ -7,7 +7,7 @@ Description:  binary file read/write routines
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 02/24/2019
 ******************************************************************************
 */
 

--- a/src/project.c
+++ b/src/project.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 01/01/2019
+ Last Updated: 02/24/2019
  ******************************************************************************
 */
 

--- a/src/quality.c
+++ b/src/quality.c
@@ -7,7 +7,7 @@ Description:  implements EPANET's water quality engine
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 02/24/2019
 ******************************************************************************
 */
 
@@ -67,6 +67,9 @@ int openqual(Project *pr)
 
     int errcode = 0;
     int n;
+
+	// Return if no quality analysis requested
+	if (qual->Qualflag == NONE) return errcode;
 
     // Build nodal adjacency lists if they don't already exist
     if (net->Adjlist == NULL)
@@ -401,12 +404,16 @@ int closequal(Project *pr)
     Quality *qual = &pr->quality;
     int errcode = 0;
 
-    if (qual->SegPool) mempool_delete(qual->SegPool);
-    FREE(qual->FirstSeg);
-    FREE(qual->LastSeg);
-    FREE(qual->PipeRateCoeff);
-    FREE(qual->FlowDir);
-    FREE(qual->SortedNodes);
+	if (qual->Qualflag != NONE)
+    {
+        if (qual->SegPool) mempool_delete(qual->SegPool);
+        FREE(qual->FirstSeg);
+        FREE(qual->LastSeg);
+        FREE(qual->PipeRateCoeff);
+        FREE(qual->FlowDir);
+        FREE(qual->SortedNodes);
+    }
+	if (pr->outfile.OutFile) fclose(pr->outfile.OutFile);
     return errcode;
 }
 

--- a/src/report.c
+++ b/src/report.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 02/24/2019
  ******************************************************************************
 */
 
@@ -540,6 +540,7 @@ int writeresults(Project *pr)
   //-----------------------------------------------------------
 
     // Return if no output file
+	outFile = fopen(pr->outfile.OutFname, "r+b");
     if (outFile == NULL) return 106;
 
     // Return if no nodes or links selected for reporting
@@ -559,8 +560,7 @@ int writeresults(Project *pr)
     n = MAX((net->Nnodes + 1), (net->Nlinks + 1));
     x = (Pfloat *)calloc(m, sizeof(Pfloat));
     ERRCODE(MEMCHECK(x));
-    if (errcode) return errcode;
-    for (j = 0; j < m; j++)
+    if (!errcode) for (j = 0; j < m; j++)
     {
         x[j] = (REAL4 *)calloc(n, sizeof(REAL4));
         if (x[j] == NULL) errcode = 101;
@@ -595,6 +595,7 @@ int writeresults(Project *pr)
     // Free allocated memory
     for (j = 0; j < m; j++) free(x[j]);
     free(x);
+	if (outFile) fclose(outFile);
     return errcode;
 }
 

--- a/win_build/WinSDK/epanet2.def
+++ b/win_build/WinSDK/epanet2.def
@@ -11,6 +11,7 @@ EXPORTS
     ENclose                       = _ENclose@0                          
     ENcloseH                      = _ENcloseH@0                         
     ENcloseQ                      = _ENcloseQ@0
+    ENcopyreport                  = _ENcopyreport@4
     ENdeletecontrol               = _ENdeletecontrol@4
     ENdeletelink                  = _ENdeletelink@8
     ENdeletenode                  = _ENdeletenode@8
@@ -78,7 +79,7 @@ EXPORTS
     ENsaveinpfile                 = _ENsaveinpfile@4                    
     ENsetbasedemand               = _ENsetbasedemand@12
     ENsetcontrol                  = _ENsetcontrol@24                    
-    ENsetcoord                    = _ENsetcoord@12
+    ENsetcoord                    = _ENsetcoord@20
     ENsetcurve                    = _ENsetcurve@16                    
     ENsetcurvevalue               = _ENsetcurvevalue@16               
     ENsetdemandmodel              = _ENsetdemandmodel@16


### PR DESCRIPTION
1. Changes arguments of 2.1 legacy functions `ENgetcoords `and `ENsetcoords` to doubles.
2. Closes the binary output file in `ENcloseQ` so that an external client can read from it while a project is still opened.
3. Closes a project input file immediately after project data is read from it.