### PR TITLE
Cleaning up test build 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,38 +21,38 @@ if(UNIX)
 endif(UNIX)
 
 #Prep ourselves for compiling boost
-if(MSVC)
+IF(MSVC)
     set(Boost_DEBUG                 OFF)
     set(Boost_DETAILED_FAILURE_MSG  OFF)
     set(Boost_USE_STATIC_LIBS       ON)
-endif(MSVC)
+ENDIF(MSVC)
 set(Boost_THREAD_FOUND              OFF)
-find_package(Boost COMPONENTS system thread filesystem)
+find_package(Boost COMPONENTS unit_test_framework system thread filesystem)
 include_directories (${Boost_INCLUDE_DIRS})
 
 
 #I like to keep test files in a separate source directory called test
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} test_*.cpp)
 
-
 #Run through each source
 foreach(testSrc ${TEST_SRCS})
-        #Extract the filename without an extension (NAME_WE)
-        get_filename_component(testName ${testSrc} NAME_WE)
+    #Extract the filename without an extension (NAME_WE)
+    get_filename_component(testName ${testSrc} NAME_WE)
 
-        #Add compile target
-        add_executable(${testName} ${testSrc})
+    #Add compile target
+    add_executable(${testName} ${testSrc})
 
-        #link to Boost libraries AND your targets and dependencies
-        IF(MSVC)
-            target_link_libraries(${testName} ${Boost_LIBRARIES} epanet2 epanet-output)
-        ELSE(TRUE)
-            target_link_libraries(${testName} ${Boost_LIBRARIES} pthread epanet2 epanet-output)
-        ENDIF(MSVC)
 
-        #Finally add it to test execution
-        #Notice the WORKING_DIRECTORY and COMMAND
-        add_test(NAME ${testName}
-                 COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testName}
-                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)
+    #link to Boost libraries AND your targets and dependencies
+    IF(MSVC)
+        target_link_libraries(${testName} ${Boost_LIBRARIES} epanet2 epanet-output)
+    ELSE(TRUE)
+        target_link_libraries(${testName} ${Boost_LIBRARIES} pthread epanet2 epanet-output)
+    ENDIF(MSVC)
+
+    #Finally add it to test execution
+    #Notice the WORKING_DIRECTORY and COMMAND
+    add_test(NAME ${testName}
+        COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testName}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)
 endforeach(testSrc)

--- a/tests/shared_test.hpp
+++ b/tests/shared_test.hpp
@@ -1,5 +1,7 @@
 
 
+//#define BOOST_TEST_DYN_LINK
+
 #include <string>
 #include <math.h>
 

--- a/tests/test_addrule.cpp
+++ b/tests/test_addrule.cpp
@@ -7,53 +7,26 @@ nodes and links from a project. Deletion can be conditional on
 node or link appearing in any simple or rule-based controls.
 */
 
-//#define NO_BOOST
 
-#ifndef NO_BOOST
-#define BOOST_TEST_MODULE "toolkit"
-#include <boost/test/included/unit_test.hpp>
-#endif
+#define BOOST_TEST_MODULE "rules"
 
-#include <iostream>
-#include <string>
-#include "epanet2_2.h"
+#include "shared_test.hpp"
 
-#define DATA_PATH_INP "./net1.inp"
-#define DATA_PATH_RPT "./test.rpt"
-#define DATA_PATH_OUT "./test.out"
-
-#ifdef NO_BOOST
-#define BOOST_REQUIRE(x) (((x)) ? cout << "\nPassed at line " << __LINE__ : cout << "\nFailed at line " << __LINE__ )
-#endif
-
-using namespace std;
 
 char R1[] = "RULE 1 \n IF NODE 2 LEVEL < 100 \n THEN LINK 9 STATUS = OPEN";
 char R2[] = "RULE 2\nIF SYSTEM TIME = 4\nTHEN LINK 9 STATUS = CLOSED\nAND LINK 31 STATUS = CLOSED";
 char R3[] = "RULE 3\nIF NODE 23 PRESSURE ABOVE 140\nAND NODE 2 LEVEL > 120\n"
             "THEN LINK 113 STATUS = CLOSED\nELSE LINK 22 STATUS = CLOSED";
 
-#ifndef NO_BOOST
-BOOST_AUTO_TEST_SUITE (test_toolkit)
-BOOST_AUTO_TEST_CASE(test_setlinktype)
-#else
-int main(int argc, char *argv[])
-#endif
+
+BOOST_AUTO_TEST_SUITE (test_addrule)
+
+BOOST_FIXTURE_TEST_CASE(test_add_get_rule,  FixtureOpenClose)
 {
-    int error = 0;
     int ruleCount, nP, nTA, nEA;
     int link113, node23, link22, pump9_before, pump9_after;
     double priority;
 
-    EN_Project ph = NULL;
-    EN_createproject(&ph);
-
-    std::string path_inp = std::string(DATA_PATH_INP);
-    std::string path_rpt = std::string(DATA_PATH_RPT);
-    std::string path_out = std::string(DATA_PATH_OUT);
-
-    error = EN_open(ph, path_inp.c_str(), path_rpt.c_str(), "");
-    BOOST_REQUIRE(error == 0);
 
     // Add the 3 rules to the project
     error = EN_addrule(ph, R1);
@@ -65,45 +38,39 @@ int main(int argc, char *argv[])
 
     // Check that rules were added
     error = EN_getcount(ph, EN_RULECOUNT, &ruleCount);
-    BOOST_REQUIRE(ruleCount == 3);
+    BOOST_CHECK(ruleCount == 3);
 
     // Check the number of clauses in rule 3
     error = EN_getrule(ph, 3, &nP, &nTA, &nEA, &priority);
-    BOOST_REQUIRE(nP == 2);
-    BOOST_REQUIRE(nTA == 1);
-    BOOST_REQUIRE(nTA == 1);
+    BOOST_CHECK(nP == 2);
+    BOOST_CHECK(nTA == 1);
+    BOOST_CHECK(nTA == 1);
 
     // Try to delete link 113 conditionally which will fail
     // because it's in rule 3
-    EN_getlinkindex(ph, "113", &link113);
+    EN_getlinkindex(ph, (char *)"113", &link113);
     error = EN_deletelink(ph, link113, EN_CONDITIONAL);
     BOOST_REQUIRE(error == 261);
 
     // Delete node 23 unconditionally which will result in the
     // deletion of rule 3 as well as links 22 and 113
-    EN_getnodeindex(ph, "23", &node23);
-    EN_getlinkindex(ph, "22", &link22);
-    EN_getlinkindex(ph, "9", &pump9_before);
+    EN_getnodeindex(ph, (char *)"23", &node23);
+    EN_getlinkindex(ph, (char *)"22", &link22);
+    EN_getlinkindex(ph, (char *)"9", &pump9_before);
     error = EN_deletenode(ph, node23, EN_UNCONDITIONAL);
     BOOST_REQUIRE(error == 0);
 
     // Check that there are now only 2 rules
     error = EN_getcount(ph, EN_RULECOUNT, &ruleCount);
-    BOOST_REQUIRE(ruleCount == 2);
+    BOOST_CHECK(ruleCount == 2);
 
     // Check that link 22 no longer exists
-    error = EN_getlinkindex(ph, "22", &link22);
-    BOOST_REQUIRE(error > 0);
+    error = EN_getlinkindex(ph, (char *)"22", &link22);
+    BOOST_CHECK(error > 0);
 
     // Check that the index of pump9 has been reduced by 2
-    error = EN_getlinkindex(ph, "9", &pump9_after);
-    BOOST_REQUIRE(pump9_before - pump9_after == 2);
-
-    // Close and delete project
-    error = EN_close(ph);
-    BOOST_REQUIRE(error == 0);
-    EN_deleteproject(&ph);
+    error = EN_getlinkindex(ph, (char *)"9", &pump9_after);
+    BOOST_CHECK(pump9_before - pump9_after == 2);
 }
-#ifndef NO_BOOST
+
 BOOST_AUTO_TEST_SUITE_END()
-#endif

--- a/tests/test_demand_categories.cpp
+++ b/tests/test_demand_categories.cpp
@@ -7,40 +7,22 @@ This is a test for the demand categories names get\set APIs
 A demand category name is set, the network is saved, reopened and the new demand category name is checked.
 */
 
-#define BOOST_TEST_MODULE "toolkit"
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_MODULE "demands"
 
-#include <string>
-#include "epanet2_2.h"
+#include "shared_test.hpp"
 
-// NOTE: Project Home needs to be updated to run unit test
-#define DATA_PATH_INP "./net1.inp"
-#define DATA_PATH_RPT "./test.rpt"
-#define DATA_PATH_OUT "./test.out"
 
-using namespace std;
+BOOST_AUTO_TEST_SUITE (test_demands)
 
-boost::test_tools::predicate_result check_string(std::string test, std::string ref)
+BOOST_AUTO_TEST_CASE(test_categories_save)
 {
-	if (ref.compare(test) == 0)
-		return true;
-	else
-		return false;
-}
-
-BOOST_AUTO_TEST_SUITE (test_toolkit)
-
-BOOST_AUTO_TEST_CASE(test_demand_categories)
-{
-	string path_inp(DATA_PATH_INP);
-	string inp_save("net1_dem_cat.inp");
-	string path_rpt(DATA_PATH_RPT);
-	string path_out(DATA_PATH_OUT);
+	std::string path_inp(DATA_PATH_NET1);
+	std::string inp_save("net1_dem_cat.inp");
+	std::string path_rpt(DATA_PATH_RPT);
+	std::string path_out(DATA_PATH_OUT);
 
 	char node_id[] = "12";
 	char demand_category[] = "Demand category name";
-	char demname[80];
-
 
 	int error = 0;
     int Nindex, ndem;
@@ -65,6 +47,22 @@ BOOST_AUTO_TEST_CASE(test_demand_categories)
 	BOOST_REQUIRE(error == 0);
 	error = EN_deleteproject(&ph);
 	BOOST_REQUIRE(error == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_categories_reopen, * boost::unit_test::depends_on("test_demands/test_categories_save"))
+{
+    std::string inp_save("net1_dem_cat.inp");
+    std::string path_rpt(DATA_PATH_RPT);
+    std::string path_out(DATA_PATH_OUT);
+
+    char node_id[] = "12";
+    char demand_category[] = "Demand category name";
+    char demname[80];
+
+    int error = 0;
+    int Nindex, ndem;
+
+    EN_Project ph = NULL;
 
 	BOOST_TEST_CHECKPOINT("Reopening saved input file");
     error = EN_createproject(&ph);

--- a/tests/test_hydrqual.cpp
+++ b/tests/test_hydrqual.cpp
@@ -7,7 +7,6 @@
 //         US EPA - ORD/NRMRL
 //
 
-//#define BOOST_TEST_DYN_LINK
 
 //#ifdef _WIN32
 //#define _CRTDBG_MAP_ALLOC
@@ -20,7 +19,7 @@
 
 #define BOOST_TEST_MODULE hydrqual
 
-#include "test_shared.hpp"
+#include "shared_test.hpp"
 
 
 using namespace std;

--- a/tests/test_net_builder_2.cpp
+++ b/tests/test_net_builder_2.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     EN_Project ph = NULL;
     EN_createproject(&ph);
     EN_init(ph, "", "", EN_GPM, EN_HW);
-    
+
     // Build a network
     EN_addnode(ph, (char *)"N1", EN_JUNCTION);
     EN_addnode(ph, (char *)"N2", EN_JUNCTION);
@@ -56,10 +56,10 @@ int main(int argc, char *argv[])
 
     // Set network data using the new helper functions
     EN_setcurvevalue(ph, 1, 1, 1500, 250);
-    EN_setjuncdata(ph, 1, 700, 500, "");
-    EN_setjuncdata(ph, 2, 710, 500, "");
+    EN_setjuncdata(ph, 1, 700, 500, (char *)"");
+    EN_setjuncdata(ph, 2, 710, 500, (char *)"");
     EN_setnodevalue(ph, 3, EN_ELEVATION, 800);
-    EN_settankdata(ph, 4, 850, 120, 100, 150, 50.5, 0, "");
+    EN_settankdata(ph, 4, 850, 120, 100, 150, 50.5, 0, (char *)"");
     EN_setlinkvalue(ph, 1, EN_PUMP_HCURVE, 1);
     EN_setpipedata(ph, 2, 10560, 12, 100, 0);
     EN_setpipedata(ph, 3, 5280, 14, 100, 0);

--- a/tests/test_node.cpp
+++ b/tests/test_node.cpp
@@ -18,12 +18,12 @@ using namespace boost;
 
 
 
-BOOST_AUTO_TEST_SUITE (test_node)
+BOOST_AUTO_TEST_SUITE (node_props_after_open)
 
-
-BOOST_FIXTURE_TEST_CASE(test_node_getvalue, FixtureOpenClose)
+BOOST_FIXTURE_TEST_CASE(test_junc_props, FixtureOpenClose)
 {
-    const auto junc_props = {
+    int index;
+    const auto props = {
         EN_ELEVATION,
         EN_BASEDEMAND,
         EN_PATTERN,
@@ -34,45 +34,110 @@ BOOST_FIXTURE_TEST_CASE(test_node_getvalue, FixtureOpenClose)
         //pressure
         //quality
     };
-    const int num_props = 5;
+    const size_t num_props = 5;
 
     std::vector<double> test (num_props);
     double *value = test.data();
 
+    error = EN_getnodeindex(ph, "11", &index);
     std::vector<double> ref = {710.0, 150.0, 1.0, 0.0, 0.5};
 
 
-    for (EN_NodeProperty p : junc_props) {
-         error = EN_getnodevalue(ph, 2, p, value++);
+    // Ranged for loop iterates over property set
+    for (EN_NodeProperty p : props) {
+         error = EN_getnodevalue(ph, index, p, value++);
          BOOST_REQUIRE(error == 0);
     }
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(ref.begin(), ref.end(), test.begin(), test.end());
-
-
-    const auto tank_props = {
-        EN_ELEVATION,
-        EN_INITQUAL,
-        EN_TANKLEVEL,
-        EN_INITVOLUME,
-        EN_MIXMODEL,
-        EN_MIXZONEVOL,
-        //demand
-        //head
-        //pressure
-        //quality
-        EN_TANKDIAM,
-        EN_MINVOLUME,
-        EN_MAXVOLUME,
-        EN_VOLCURVE,
-        EN_MINLEVEL,
-        EN_MAXLEVEL,
-        EN_MIXFRACTION,
-        EN_TANK_KBULK,
-        EN_TANKVOLUME
-    };
-
+    BOOST_CHECK(check_cdd_double(test, ref, 3));
 }
 
+BOOST_FIXTURE_TEST_CASE(test_tank_props, FixtureOpenClose)
+{
+    int index;
+    const auto props = {
+        EN_ELEVATION,
+        EN_TANKLEVEL,
+        EN_MINLEVEL,
+        EN_MAXLEVEL,
+        EN_TANKDIAM,
+        EN_MINVOLUME
+    };
+    const size_t num_props = 6;
+
+    std::vector<double> test (num_props);
+    double *value = test.data();
+
+    error = EN_getnodeindex(ph, "2", &index);
+    std::vector<double> ref = {850.0, 120.0, 100.0, 150.0, 50.5, 200296.167};
+
+    // Ranged for loop iterates over property set
+    for (EN_NodeProperty p : props) {
+        error = EN_getnodevalue(ph, index, p, value++);
+        BOOST_REQUIRE(error == 0);
+    }
+
+    BOOST_CHECK(check_cdd_double(test, ref, 3));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+
+
+BOOST_AUTO_TEST_SUITE(node_props_after_step)
+
+BOOST_FIXTURE_TEST_CASE(test_junc_props, FixtureAfterStep)
+{
+    int index;
+    const auto props = {
+        EN_DEMAND,
+        EN_HEAD,
+        EN_PRESSURE,
+        EN_QUALITY
+    };
+    const size_t num_props = 4;
+
+    std::vector<double> test (num_props);
+    double *value = test.data();
+
+    error = EN_getnodeindex(ph, "11", &index);
+    std::vector<double> ref = {179.999, 991.574, 122.006, 0.857};
+
+
+    // Ranged for loop iterates over property set
+    for (EN_NodeProperty p : props) {
+         error = EN_getnodevalue(ph, index, p, value++);
+         BOOST_REQUIRE(error == 0);
+    }
+
+    BOOST_CHECK(check_cdd_double(test, ref, 3));
+}
+
+BOOST_FIXTURE_TEST_CASE(test_tank_props, FixtureAfterStep)
+{
+    int index;
+    const auto props = {
+        EN_DEMAND,
+        EN_HEAD,
+        EN_PRESSURE,
+        EN_QUALITY
+    };
+    const size_t num_props = 4;
+
+    std::vector<double> test (num_props);
+    double *value = test.data();
+
+    error = EN_getnodeindex(ph, "2", &index);
+    std::vector<double> ref = {505.383, 978.138, 55.522, 0.911};
+
+    // Ranged for loop iterates over property set
+    for (EN_NodeProperty p : props) {
+        error = EN_getnodevalue(ph, index, p, value++);
+        BOOST_REQUIRE(error == 0);
+    }
+
+    BOOST_CHECK(check_cdd_double(test, ref, 3));
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_node.cpp
+++ b/tests/test_node.cpp
@@ -10,7 +10,7 @@
 
 #define BOOST_TEST_MODULE "node"
 
-#include "test_shared.hpp"
+#include "shared_test.hpp"
 
 
 BOOST_AUTO_TEST_SUITE (node_props_after_open)
@@ -30,7 +30,7 @@ BOOST_FIXTURE_TEST_CASE(test_junc_props, FixtureOpenClose)
     std::vector<double> test (num_props);
     double *value = test.data();
 
-    error = EN_getnodeindex(ph, "11", &index);
+    error = EN_getnodeindex(ph, (char *)"11", &index);
     std::vector<double> ref = {710.0, 150.0, 1.0, 0.0, 0.5};
 
 
@@ -59,7 +59,7 @@ BOOST_FIXTURE_TEST_CASE(test_tank_props, FixtureOpenClose)
     std::vector<double> test (num_props);
     double *value = test.data();
 
-    error = EN_getnodeindex(ph, "2", &index);
+    error = EN_getnodeindex(ph, (char *)"2", &index);
     std::vector<double> ref = {850.0, 120.0, 100.0, 150.0, 50.5, 200296.167};
 
     // Ranged for loop iterates over property set
@@ -92,7 +92,7 @@ BOOST_FIXTURE_TEST_CASE(test_junc_props, FixtureAfterStep)
     std::vector<double> test (num_props);
     double *value = test.data();
 
-    error = EN_getnodeindex(ph, "11", &index);
+    error = EN_getnodeindex(ph, (char *)"11", &index);
     std::vector<double> ref = {179.999, 991.574, 122.006, 0.857};
 
 
@@ -119,7 +119,7 @@ BOOST_FIXTURE_TEST_CASE(test_tank_props, FixtureAfterStep)
     std::vector<double> test (num_props);
     double *value = test.data();
 
-    error = EN_getnodeindex(ph, "2", &index);
+    error = EN_getnodeindex(ph, (char *)"2", &index);
     std::vector<double> ref = {505.383, 978.138, 55.522, 0.911};
 
     // Ranged for loop iterates over property set

--- a/tests/test_node.cpp
+++ b/tests/test_node.cpp
@@ -13,11 +13,6 @@
 #include "test_shared.hpp"
 
 
-using namespace std;
-using namespace boost;
-
-
-
 BOOST_AUTO_TEST_SUITE (node_props_after_open)
 
 BOOST_FIXTURE_TEST_CASE(test_junc_props, FixtureOpenClose)
@@ -29,10 +24,6 @@ BOOST_FIXTURE_TEST_CASE(test_junc_props, FixtureOpenClose)
         EN_PATTERN,
         EN_EMITTER,
         EN_INITQUAL,
-        //demand
-        //head
-        //pressure
-        //quality
     };
     const size_t num_props = 5;
 

--- a/tests/test_proj.cpp
+++ b/tests/test_proj.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE (test_proj_create_delete)
 
 BOOST_AUTO_TEST_CASE (test_proj_open_close)
 {
-	string path_inp(DATA_PATH_INP);
+	string path_inp(DATA_PATH_NET1);
 	string path_rpt(DATA_PATH_RPT);
     string path_out(DATA_PATH_OUT);
 
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(test_proj_savefile)
 {
     int error;
 
-    string path_inp(DATA_PATH_INP);
+    string path_inp(DATA_PATH_NET1);
     string inp_save("test_reopen.inp");
 	string path_rpt(DATA_PATH_RPT);
 	string path_out(DATA_PATH_OUT);
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(test_proj_reopen, * unit_test::depends_on("test_proj/test_p
 
 BOOST_AUTO_TEST_CASE(test_proj_run)
 {
-    string path_inp(DATA_PATH_INP);
+    string path_inp(DATA_PATH_NET1);
     string path_rpt(DATA_PATH_RPT);
     string path_out(DATA_PATH_OUT);
 

--- a/tests/test_proj.cpp
+++ b/tests/test_proj.cpp
@@ -7,29 +7,28 @@
 //         US EPA - ORD/NRMRL
 //
 
-//#define BOOST_TEST_DYN_LINK
 
 //#ifdef _WIN32
 //#define _CRTDBG_MAP_ALLOC
 //#include <stdlib.h>
 //#include <crtdbg.h>
 //#else
-#include <stdlib.h>
+//#include <stdlib.h>
 //#endif
 
 
 #define BOOST_TEST_MODULE "project"
 
-#include "test_shared.hpp"
+#include "shared_test.hpp"
 
 
 using namespace std;
 using namespace boost;
 
 
-BOOST_AUTO_TEST_SUITE (test_proj)
+BOOST_AUTO_TEST_SUITE (test_project)
 
-BOOST_AUTO_TEST_CASE (test_proj_create_delete)
+BOOST_AUTO_TEST_CASE (test_create_delete)
 {
     int error = 0;
     EN_Project ph = NULL;
@@ -45,7 +44,7 @@ BOOST_AUTO_TEST_CASE (test_proj_create_delete)
     BOOST_CHECK(ph == NULL);
 }
 
-BOOST_AUTO_TEST_CASE (test_proj_open_close)
+BOOST_AUTO_TEST_CASE (test_open_close)
 {
 	string path_inp(DATA_PATH_NET1);
 	string path_rpt(DATA_PATH_RPT);
@@ -63,7 +62,7 @@ BOOST_AUTO_TEST_CASE (test_proj_open_close)
     EN_deleteproject(&ph);
 }
 
-BOOST_AUTO_TEST_CASE(test_proj_savefile)
+BOOST_AUTO_TEST_CASE(test_save)
 {
     int error;
 
@@ -89,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_proj_savefile)
     EN_deleteproject(&ph_save);
 }
 
-BOOST_AUTO_TEST_CASE(test_proj_reopen, * unit_test::depends_on("test_proj/test_proj_savefile"))
+BOOST_AUTO_TEST_CASE(test_reopen, * unit_test::depends_on("test_project/test_save"))
 {
     int error;
 
@@ -109,7 +108,7 @@ BOOST_AUTO_TEST_CASE(test_proj_reopen, * unit_test::depends_on("test_proj/test_p
 	EN_deleteproject(&ph_reopen);
 }
 
-BOOST_AUTO_TEST_CASE(test_proj_run)
+BOOST_AUTO_TEST_CASE(test_run)
 {
     string path_inp(DATA_PATH_NET1);
     string path_rpt(DATA_PATH_RPT);
@@ -131,7 +130,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(test_proj_fixture)
 
-BOOST_FIXTURE_TEST_CASE(test_proj_title, FixtureOpenClose)
+BOOST_FIXTURE_TEST_CASE(test_title, FixtureOpenClose)
 {
     // How is the API user supposed to know array size?
     char c_test[3][80], c_ref[3][80];
@@ -152,7 +151,7 @@ BOOST_FIXTURE_TEST_CASE(test_proj_title, FixtureOpenClose)
    // Need a test for EN_settitle
 }
 
-BOOST_FIXTURE_TEST_CASE(test_proj_getcount, FixtureOpenClose)
+BOOST_FIXTURE_TEST_CASE(test_getcount, FixtureOpenClose)
 {
     int i, array[7];
 

--- a/tests/test_rprtanlys.cpp
+++ b/tests/test_rprtanlys.cpp
@@ -20,7 +20,7 @@
 
 #define BOOST_TEST_MODULE hydqual
 
-#include "test_shared.hpp"
+#include "shared_test.hpp"
 
 
 using namespace std;

--- a/tests/test_shared.hpp
+++ b/tests/test_shared.hpp
@@ -115,7 +115,6 @@ struct FixtureAfterStep{
     }
 
     ~FixtureAfterStep() {
-
         error = EN_closeQ(ph);
         BOOST_REQUIRE(error == 0);
 

--- a/tests/test_shared.hpp
+++ b/tests/test_shared.hpp
@@ -55,13 +55,13 @@ boost::test_tools::predicate_result check_string(std::string test, std::string r
 }
 
 
-#define DATA_PATH_INP "./net1.inp"
+#define DATA_PATH_NET1 "./net1.inp"
 #define DATA_PATH_RPT "./test.rpt"
 #define DATA_PATH_OUT "./test.out"
 
 struct FixtureOpenClose{
     FixtureOpenClose() {
-        path_inp = std::string(DATA_PATH_INP);
+        path_inp = std::string(DATA_PATH_NET1);
         path_rpt = std::string(DATA_PATH_RPT);
         path_out = std::string(DATA_PATH_OUT);
 
@@ -80,4 +80,54 @@ struct FixtureOpenClose{
 
   int error;
   EN_Project ph;
+};
+
+
+struct FixtureAfterStep{
+    FixtureAfterStep() {
+        flag = 0;
+        tstop = 10800;
+
+        path_inp = std::string(DATA_PATH_NET1);
+        path_rpt = std::string(DATA_PATH_RPT);
+        path_out = std::string(DATA_PATH_OUT);
+
+        EN_createproject(&ph);
+        error = EN_open(ph, path_inp.c_str(), path_rpt.c_str(), path_out.c_str());
+
+        error = EN_solveH(ph);
+        BOOST_REQUIRE(error == 0);
+
+        error = EN_openQ(ph);
+        BOOST_REQUIRE(error == 0);
+
+        error = EN_initQ(ph, flag);
+        BOOST_REQUIRE(error == 0);
+
+        do {
+            error = EN_runQ(ph, &t);
+            BOOST_REQUIRE(error == 0);
+
+            error = EN_stepQ(ph, &tstep);
+            BOOST_REQUIRE(error == 0);
+
+        } while (tstep > 0 && t < tstop);
+    }
+
+    ~FixtureAfterStep() {
+
+        error = EN_closeQ(ph);
+        BOOST_REQUIRE(error == 0);
+
+        error = EN_close(ph);
+        EN_deleteproject(&ph);
+    }
+
+    std::string path_inp;
+    std::string path_rpt;
+    std::string path_out;
+
+    int error, flag;
+    long t, tstep, tstop;
+    EN_Project ph;
 };


### PR DESCRIPTION
Close #339 

Fixes a memory leak that was occurring when input files were saved and reopened as part of a unit test by separating the save and reopen into two different tests and defining a dependency between the two. 

Cleans up test build on gcc. 