### PR TITLE
Replace fixed-sized comment strings with dynamic strings

### DIFF
--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -5,7 +5,7 @@ Attribute VB_Name = "Module1"
 'Declarations of functions in the EPANET PROGRAMMERs TOOLKIT
 '(EPANET2.DLL)
 
-'Last updated on 02/28/2019
+'Last updated on 03/17/2019
 
 ' These are codes used by the DLL functions
 Public Const EN_ELEVATION = 0     ' Node parameters
@@ -82,6 +82,13 @@ Public Const EN_RELATIVEERROR = 1
 Public Const EN_MAXHEADERROR = 2
 Public Const EN_MAXFLOWCHANGE = 3
 Public Const EN_MASSBALANCE = 4
+
+Public Const EN_NODE = 0          ' Component types
+Public Const EN_LINK = 1
+Public Const EN_TIMEPAT = 2
+Public Const EN_CURVE = 3
+Public Const EN_CONTROL = 4
+Public Const EN_RULE = 5 
 
 Public Const EN_NODECOUNT = 0     ' Component counts
 Public Const EN_TANKCOUNT = 1

--- a/include/epanet2.def
+++ b/include/epanet2.def
@@ -21,6 +21,7 @@ EXPORTS
     ENepanet                      = _ENepanet@16
     ENgetaveragepatternvalue      = _ENgetaveragepatternvalue@8
     ENgetbasedemand               = _ENgetbasedemand@12
+    ENgetcomment                  = _ENgetcomment@12
     ENgetcontrol                  = _ENgetcontrol@24                    
     ENgetcoord                    = _ENgetcoord@12
     ENgetcount                    = _ENgetcount@8                       
@@ -80,6 +81,7 @@ EXPORTS
     ENsavehydfile                 = _ENsavehydfile@4                    
     ENsaveinpfile                 = _ENsaveinpfile@4                    
     ENsetbasedemand               = _ENsetbasedemand@12
+    ENsetcomment                  = _ENsetcomment@12
     ENsetcontrol                  = _ENsetcontrol@24                    
     ENsetcoord                    = _ENsetcoord@20
     ENsetcurve                    = _ENsetcurve@16

--- a/include/epanet2.h
+++ b/include/epanet2.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/28/2019
+ Last Updated: 03/17/2019
  ******************************************************************************
  */
 
@@ -76,6 +76,10 @@ extern "C" {
   int  DLLEXPORT ENgettitle(char *line1, char *line2, char *line3);
   
   int  DLLEXPORT ENsettitle(char *line1, char *line2, char *line3);
+
+  int  DLLEXPORT ENgetcomment(int object, int index, char *comment);
+
+  int  DLLEXPORT ENsetcomment(int object, int index, char *comment);
 
   int  DLLEXPORT ENgetcount(int object, int *count);
 

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -4,7 +4,7 @@
 'Declarations of functions in the EPANET PROGRAMMERs TOOLKIT
 '(EPANET2.DLL) for use with VB.Net.
 
-'Last updated on 02/28/2019
+'Last updated on 03/17/2019
 
 Imports System.Runtime.InteropServices
 Imports System.Text
@@ -87,6 +87,13 @@ Public Const EN_RELATIVEERROR = 1
 Public Const EN_MAXHEADERROR = 2
 Public Const EN_MAXFLOWCHANGE = 3
 Public Const EN_MASSBALANCE = 4
+
+Public Const EN_NODE = 0          ' Component types
+Public Const EN_LINK = 1
+Public Const EN_TIMEPAT = 2
+Public Const EN_CURVE = 3
+Public Const EN_CONTROL = 4
+Public Const EN_RULE = 5 
 
 Public Const EN_NODECOUNT = 0     'Component counts
 Public Const EN_TANKCOUNT = 1

--- a/include/epanet2_2.h
+++ b/include/epanet2_2.h
@@ -11,7 +11,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 03/17/2019
  ******************************************************************************
  */
 
@@ -146,6 +146,26 @@ typedef struct Project *EN_Project;
   */
   int  DLLEXPORT EN_settitle(EN_Project ph, char *line1, char *line2, char *line3);
 
+  /**
+  @brief Retrieves a descriptive comment assigned to a Node, Link, Pattern or Curve.
+  @param ph an EPANET project handle.
+  @param object a type of object (either EN_NODE, EN_LINK, EN_TIMEPAT or EN_CURVE)
+  @param index the object's index starting from 1
+  @param[out] comment the comment string assigned to the object
+  @return an error code
+  */
+  int  DLLEXPORT EN_getcomment(EN_Project ph, int object, int index, char *comment);
+
+  /**
+  @brief Assigns a descriptive comment to a Node, Link, Pattern or Curve.
+  @param ph an EPANET project handle.
+  @param object a type of object (either EN_NODE, EN_LINK, EN_TIMEPAT or EN_CURVE)
+  @param index the object's index starting from 1
+  @param[out] comment the comment string assigned to the object
+  @return an error code
+  */
+  int  DLLEXPORT EN_setcomment(EN_Project ph, int object, int index, char *comment);
+  
   /**
   @brief Retrieves the number of objects of a given type in a project.
   @param ph an EPANET project handle.

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -9,7 +9,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 01/14/2019
+ Last Updated: 03/17/2019
  ******************************************************************************
 */
 
@@ -127,6 +127,19 @@ typedef enum {
   EN_MAXFLOWCHANGE = 3, //!< Largest flow change in links
   EN_MASSBALANCE   = 4  //!< Cumulative water quality mass balance ratio
 } EN_AnalysisStatistic;
+
+/// Types of network objects
+/**
+A network model is composed of these types of objects.
+*/
+typedef enum {
+    EN_NODE    = 0,     //!< Nodes
+    EN_LINK    = 1,     //!< Links
+    EN_TIMEPAT = 2,     //!< Time patterns
+    EN_CURVE   = 3,     //!< Data curves
+    EN_CONTROL = 4,     //!< Simple controls
+    EN_RULE    = 5      //!< Control rules
+} EN_ObjectType;
 
 /// Types of objects to count
 /**

--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 03/17/2019
  ******************************************************************************
 */
 #ifndef __APPLE__
@@ -110,6 +110,16 @@ int DLLEXPORT ENgettitle(char *line1, char *line2, char *line3)
 int DLLEXPORT ENsettitle(char *line1, char *line2, char *line3)
 {
     return EN_settitle(_defaultProject, line1, line2, line3) ;
+}
+
+int DLLEXPORT ENgetcomment(int object, int index, char *comment)
+{
+    return EN_getcomment(_defaultProject, object, index, comment);
+}
+
+int  DLLEXPORT ENsetcomment(int object, int index, char *comment)
+{
+    return EN_setcomment(_defaultProject, object, index, comment);
 }
 
 int DLLEXPORT ENgetcount(int object, int *count)

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 03/17/2019
  ******************************************************************************
 */
 #ifndef FUNCS_H
@@ -39,7 +39,11 @@ int     findpump(Network *, int);
 void    adjustpatterns(Network *, int);
 void    adjustcurves(Network *, int);
 
+int     getcomment(Network *, int, int, char *);
+int     setcomment(Network *, int, int, const char *);
+
 char    *getTmpName(char *);
+char    *xstrcpy(char **, const char *, const size_t n);
 int     strcomp(const char *, const char *);
 double  interp(int, double [], double [], double);
 char    *geterrmsg(int, char *);

--- a/src/input1.c
+++ b/src/input1.c
@@ -7,7 +7,7 @@ Description:  retrieves network data from an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 12/15/2018
+Last Updated: 03/17/2019
 ******************************************************************************
 */
 
@@ -334,7 +334,7 @@ void adjustdata(Project *pr)
             if (demand->Pat == 0)
             {
                 demand->Pat = hyd->DefPat;
-                strcpy(demand->Name, "");
+                xstrcpy(&demand->Name, "", MAXMSG);
             }
         }
     }

--- a/src/types.h
+++ b/src/types.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 01/01/2019
+ Last Updated: 03/17/2019
  ******************************************************************************
 */
 
@@ -118,11 +118,15 @@ typedef  int          INT4;
 ----------------------------------------------
    Enumerated Data Types
 ----------------------------------------------
- */
+*/
 
 typedef enum {
   NODE,
-  LINK
+  LINK,
+  TIMEPAT,
+  CURVE,
+  CONTROL,
+  RULE
 } ObjectType;
 
 typedef enum {
@@ -333,6 +337,7 @@ typedef struct Tmplist STmplist; // Pointer to temporary list of objects
 typedef struct             // Time Pattern Object
 {
   char   ID[MAXID+1];      // pattern ID
+  char   *Comment;         // pattern comment
   int    Length;           // pattern length
   double *F;               // pattern factors
 } Spattern;
@@ -340,6 +345,7 @@ typedef struct             // Time Pattern Object
 typedef struct             // Curve Object
 {
   char      ID[MAXID+1];   // curve ID
+  char      *Comment;      // curve comment
   CurveType Type;          // curve type
   int       Npts;          // number of points
   double    *X;            // x-values
@@ -350,7 +356,7 @@ struct Sdemand             // Demand List Item
 {
   double Base;             // baseline demand
   int    Pat;              // pattern index
-  char   Name[MAXMSG+1];   // demand category name
+  char   *Name;            // demand category name
   struct Sdemand *next;    // next demand list item
 };
 typedef struct Sdemand *Pdemand; // Pointer to demand list
@@ -386,7 +392,7 @@ typedef struct             // Node Object
   double   Ke;             // emitter coeff.
   int      Rpt;            // reporting flag
   NodeType Type;           // node type
-  char Comment[MAXMSG+1];  // node comment
+  char     *Comment;       // node comment
 } Snode;
 
 typedef struct             // Link Object
@@ -406,7 +412,7 @@ typedef struct             // Link Object
   LinkType Type;           // link type
   StatusType Status;       // initial status
   int      Rpt;            // reporting flag
-  char Comment[MAXMSG+1];  // link Comment
+  char     *Comment;       // link comment
 } Slink;
 
 typedef struct             // Tank Object
@@ -544,10 +550,11 @@ typedef struct {
   FILE *InFile;            // Input file handle
   
   char
-    DefPatID[MAXID+1],     // Default demand pattern ID
-    InpFname[MAXFNAME+1],  // Input file name
-    *Tok[MAXTOKS],         // Array of token strings
-    Comment[MAXMSG+1];     // Comment text
+      DefPatID[MAXID + 1],     // Default demand pattern ID
+      InpFname[MAXFNAME + 1],  // Input file name
+      *Tok[MAXTOKS],           // Array of token strings
+      Comment[MAXMSG + 1],     // Comment text
+      LineComment[MAXMSG + 1]; // Full line comment
   
   int      
     MaxNodes,              // Node count   from input file */

--- a/tests/test_comments.cpp
+++ b/tests/test_comments.cpp
@@ -1,0 +1,131 @@
+// Test of EPANET's Comment Handling Functions
+//
+// This is a test of the API functions EN_getcomment and EN_setcomment
+//
+#define _CRT_SECURE_NO_DEPRECATE
+
+//#define NO_BOOST
+
+#ifndef NO_BOOST
+#define BOOST_TEST_MODULE "toolkit"
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <iostream>
+#include <string>
+#include "epanet2_2.h"
+
+#define DATA_PATH_INP "./net1.inp"
+#define DATA_PATH_RPT "./test.rpt"
+#define DATA_PATH_OUT "./test.out"
+#define DATA_PATH_TMP "./tmp.inp"
+
+#ifdef NO_BOOST
+#define BOOST_REQUIRE(x) (((x)) ? cout << "\nPassed at line " << __LINE__ : cout << "\nFailed at line " << __LINE__ )
+#endif
+
+using namespace std;
+
+int checkComments(EN_Project ph)
+{
+    int index;
+    char comment[EN_MAXMSG + 1];
+    EN_getnodeindex(ph, (char *)"11", &index);
+    EN_getcomment(ph, EN_NODE, index, comment);
+    if (strcmp(comment, (char *)"J11") != 0) return 0;
+
+    EN_getnodeindex(ph, (char *)"23", &index);
+    EN_getcomment(ph, EN_NODE, index, comment);
+    if (strcmp(comment, (char *)"Junc23") != 0) return 0;
+
+    EN_getlinkindex(ph, (char *)"11", &index);
+    EN_getcomment(ph, EN_LINK, index, comment);
+    if (strcmp(comment, (char *)"P11") != 0) return 0;
+
+    EN_getlinkindex(ph, (char *)"9", &index);
+    EN_getcomment(ph, EN_LINK, index, comment);
+    if (strcmp(comment, (char *)"Pump9") != 0) return 0;
+
+    EN_getpatternindex(ph, (char *)"1", &index);
+    EN_getcomment(ph, EN_TIMEPAT, index, comment);
+    if (strcmp(comment, (char *)"Time Pattern 1") != 0) return 0;
+
+    EN_getcurveindex(ph, (char *)"1", &index);
+    EN_getcomment(ph, EN_CURVE, index, comment);
+    if (strcmp(comment, (char *)"Curve 1") != 0) return 0;
+    return 1;
+}
+
+#ifndef NO_BOOST
+BOOST_AUTO_TEST_SUITE (test_toolkit)
+BOOST_AUTO_TEST_CASE(test_setlinktype)
+{
+#else
+int main(int argc, char *argv[])
+{
+#endif
+
+    int error = 0;
+    int index;
+    char comment[EN_MAXMSG+1];
+
+    // Create & load a project
+    EN_Project ph = NULL;
+    EN_createproject(&ph);
+    std::string path_inp = string(DATA_PATH_INP);
+    std::string path_rpt = string(DATA_PATH_RPT);
+    std::string path_out = string(DATA_PATH_OUT);
+    error = EN_open(ph, path_inp.c_str(), path_rpt.c_str(), "");
+    BOOST_REQUIRE(error == 0);
+
+    // Add comments to selected objects
+    EN_getnodeindex(ph, (char *)"11", &index);
+    EN_setcomment(ph, EN_NODE, index, (char *)"J11");
+    EN_getnodeindex(ph, (char *)"23", &index);
+    EN_setcomment(ph, EN_NODE, index, (char *)"Junc23");
+    EN_getlinkindex(ph, (char *)"11", &index);
+
+    EN_setcomment(ph, EN_LINK, index, (char *)"P11");
+    EN_getlinkindex(ph, (char *)"9", &index);
+    EN_setcomment(ph, EN_LINK, index, (char *)"Pump9");
+
+    EN_getpatternindex(ph, (char *)"1", &index);
+    EN_setcomment(ph, EN_TIMEPAT, index, (char *)"Time Pattern 1");
+
+    EN_getcurveindex(ph, (char *)"1", &index);
+    EN_setcomment(ph, EN_CURVE, index, (char *)"Curve 1");
+
+    // Retrieve comments and test their values
+    BOOST_REQUIRE(checkComments(ph) == 1);
+
+    // Replace short comment with longer one and vice versa
+    EN_getnodeindex(ph, (char *)"11", &index);
+    EN_setcomment(ph, EN_NODE, index, (char *)"Junction11");
+    EN_getcomment(ph, EN_NODE, index, comment);
+    BOOST_REQUIRE(strcmp(comment, (char *)"Junction11") == 0);
+    EN_setcomment(ph, EN_NODE, index, (char *)"J11");
+    EN_getcomment(ph, EN_NODE, index, comment);
+    BOOST_REQUIRE(strcmp(comment, (char *)"J11") == 0);
+    
+    // Save & re-open project
+    string path_tmp = string(DATA_PATH_TMP);
+    EN_saveinpfile(ph, path_tmp.c_str());
+    EN_close(ph);
+    error = EN_open(ph, path_tmp.c_str(), path_rpt.c_str(), "");
+    BOOST_REQUIRE(error == 0);
+
+    // Check that comments were saved & read correctly
+    BOOST_REQUIRE(checkComments(ph) == 1);
+    remove(path_tmp.c_str());
+
+    // Close project
+    EN_close(ph);
+    EN_deleteproject(&ph);
+
+#ifdef NO_BOOST
+    return 0;
+#endif
+}
+#ifndef NO_BOOST
+BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/win_build/WinSDK/epanet2.def
+++ b/win_build/WinSDK/epanet2.def
@@ -21,6 +21,7 @@ EXPORTS
     ENepanet                      = _ENepanet@16
     ENgetaveragepatternvalue      = _ENgetaveragepatternvalue@8
     ENgetbasedemand               = _ENgetbasedemand@12
+    ENgetcomment                  = _ENgetcomment@12
     ENgetcontrol                  = _ENgetcontrol@24                    
     ENgetcoord                    = _ENgetcoord@12
     ENgetcount                    = _ENgetcount@8                       
@@ -80,6 +81,7 @@ EXPORTS
     ENsavehydfile                 = _ENsavehydfile@4                    
     ENsaveinpfile                 = _ENsaveinpfile@4                    
     ENsetbasedemand               = _ENsetbasedemand@12
+    ENsetcomment                  = _ENsetcomment@12
     ENsetcontrol                  = _ENsetcontrol@24                    
     ENsetcoord                    = _ENsetcoord@20
     ENsetcurve                    = _ENsetcurve@16


### PR DESCRIPTION
This commit addresses issue #422.  It also adds a new unit test named `test_comments.cpp `to test the switch to dynamic comment strings along with the new API functions `EN_getcomment` and `EN_setcomment`.