### PR TITLE
Fix NULL pointer error if rules label is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 EPANET {#epanet-readme}
 ======
 
-[![Build Status](https://travis-ci.org/OpenWaterAnalytics/EPANET.svg?branch=dev-2.1)](https://travis-ci.org/OpenWaterAnalytics/EPANET)
+[![Build Status](https://travis-ci.org/OpenWaterAnalytics/EPANET.svg?branch=master)](https://travis-ci.org/OpenWaterAnalytics/EPANET)
 
 The EPANET Library is a pressurized pipe network hydraulic and water quality analysis toolkit written in C. 
 
 If you are interested in using/extending EPANET for academic, personal, or commercial use, then you've come to the right place. For community discussion, FAQ, and roadmapping of the project, go to the [Community Forum](http://community.wateranalytics.org/category/epanet). 
 
-Please see the [`version 2.1` Roadmap](https://github.com/OpenWaterAnalytics/EPANET/milestones/v2.1) for ongoing areas of development. If you would like to contribute by addressing any of the outstanding [Issues](https://github.com/OpenWaterAnalytics/EPANET/issues), then please comment on the Issue, then Fork this repo to your own account and base your commits on the [`dev-2.1` branch](https://github.com/OpenWaterAnalytics/EPANET/tree/dev-2.1). Once you are finished, you can open a Pull Request to test the code and discuss merging your changes back into the community respository.
+Please see the [`version 2.1` Release Notes](https://github.com/OpenWaterAnalytics/EPANET/blob/master/ReleaseNotes2_1.md) for information relevant to users of the previous official version (2.00.12). If you would like to contribute by addressing any of the outstanding [Issues](https://github.com/OpenWaterAnalytics/EPANET/issues), then please comment on the Issue, then Fork this repo to your own account and base your commits on the [`dev` branch](https://github.com/OpenWaterAnalytics/EPANET/tree/dev). Once you are finished, you can open a Pull Request to test the code and discuss merging your changes back into the community respository.
 
-__Note:__ This repository is not affiliated with, or endorsed by, the USEPA. For the "official" release of EPANET (2.00.12 UI and Toolkit) please go to the [EPA's GitHub repo](https://github.com/USEPA/Water-Distribution-Network-Model) or [the USEPA website](http://www2.epa.gov/water-research/epanet). It is also not the graphical user interface version. This is the hydraulic and water quality solver engine.
+__Note:__ This repository is not affiliated with, or endorsed by, the USEPA. For the last "official" release of EPANET (2.00.12 UI and Toolkit) please go to the [EPA's GitHub repo](https://github.com/USEPA/Water-Distribution-Network-Model) or [the USEPA website](http://www2.epa.gov/water-research/epanet). It is also not the graphical user interface version. This is the hydraulic and water quality solver engine.
 
 However, if you are interested in extending EPANET for academic, personal, or commercial use, then you've come to the right place. For community discussion, FAQ, and roadmapping of the project, go to the [Community Forum](http://community.wateranalytics.org/category/epanet). 
-
-Please see the [`version 2.1` Roadmap](https://github.com/OpenWaterAnalytics/EPANET/milestones/v2.1) for ongoing areas of development. If you would like to contribute by addressing any of the outstanding [Issues](https://github.com/OpenWaterAnalytics/EPANET/issues), then please comment on the Issue, then Fork this repo to your own account and base your commits on the [`dev-2.1` branch](https://github.com/OpenWaterAnalytics/EPANET/tree/dev-2.1). Once you are finished, you can open a Pull Request to test the code and discuss merging your changes back into the community respository.

--- a/src/rules.c
+++ b/src/rules.c
@@ -237,7 +237,13 @@ int  ruledata()
    {
       case -1:     err = 201;      /* Unrecognized keyword */
                    break;
-      case r_RULE: Nrules++;
+      case r_RULE: /* Missing the rule label -> set error */
+                   if (parser->Ntokens != 2)
+                   {
+                      err = 201;
+                      break;
+                   }
+                   Nrules++;
                    newrule();
                    RuleState = r_RULE;
                    break;


### PR DESCRIPTION
If no label is provided after the RULE keyword, EPANET crashes. This fixes the crash by returning an error in the case the label is missing.