### PR TITLE
build and go batch file

### DIFF
--- a/makefile.bat
+++ b/makefile.bat
@@ -7,12 +7,15 @@
 ::          US EPA - ORD/NRMRL
 ::
 :: Requires:
-::     CMake
-::     Visual Studio Build Tools
+::    Visual Studio downloads:
+::      https://visualstudio.microsoft.com/downloads/
+::
+::    CMake download:
+::      https://cmake.org/download/
 ::
 :: Note:
-::     This script must be located at the root of the project folder
-::     in order to work properly.
+::    This script must be located at the root of the project folder
+::    in order to work properly.
 ::
 
 @echo off

--- a/makefile.bat
+++ b/makefile.bat
@@ -7,7 +7,7 @@
 ::          US EPA - ORD/NRMRL
 ::
 :: Requires:
-::    Visual Studio downloads:
+::    Build Tools for Visual Studio download:
 ::      https://visualstudio.microsoft.com/downloads/
 ::
 ::    CMake download:

--- a/makefile.bat
+++ b/makefile.bat
@@ -1,0 +1,45 @@
+::
+::  makefile.bat - build epanet and go do whatever
+::
+::  Date Created: 5/2/2019
+::
+::  Author: Michael E. Tryby
+::          US EPA - ORD/NRMRL
+::
+:: Requires:
+::     CMake
+::     Visual Studio Build Tools
+::
+:: Note:
+::     This script must be located at the root of the project folder
+::     in order to work properly.
+::
+
+@echo off
+echo INFO: Building epanet  ...
+
+set GENERATOR=Visual Studio 15 2017
+
+:: Determine project path and strip trailing \ from path
+set "PROJECT_PATH=%~dp0"
+IF %PROJECT_PATH:~-1%==\ set "PROJECT_PATH=%PROJECT_PATH:~0,-1%"
+
+:: check for requirements
+WHERE cmake
+IF %ERRORLEVEL% NEQ 0 ECHO cmake not installed & EXIT /B 1
+
+:: generate build system
+IF exist buildprod_win32 ( cd buildprod_win32 ) ELSE ( mkdir buildprod_win32 & cd buildprod_win32 )
+cmake -G"%GENERATOR%" -DBUILD_TESTS=OFF ..
+
+cd ..
+IF exist buildprod_win64 ( cd buildprod_win64 ) ELSE ( mkdir buildprod_win64 & cd buildprod_win64 )
+cmake -G"%GENERATOR% Win64" -DBUILD_TESTS=OFF ..
+
+:: perform build
+cmake --build . --config Release
+cd .. & cd buildprod_win32
+cmake --build . --config Release
+
+:: return to project root
+cd %PROJECT_PATH%

--- a/src/util/cstr_helper.c
+++ b/src/util/cstr_helper.c
@@ -19,6 +19,7 @@
 
 int cstr_duplicate(char **dest, const char *source)
 // Duplicates source string
+// Be advised: Caller is responsible for freeing dest string
 {
     size_t size = 1 + strlen(source);
     *dest = (char *) calloc(size, sizeof(char));

--- a/src/util/cstr_helper.h
+++ b/src/util/cstr_helper.h
@@ -23,10 +23,20 @@ extern "C" {
 #endif
 
 
+/**
+@brief Duplicates the source string and returns a null terminated copy.
+*/
 int cstr_duplicate(char **dest, const char *source);
 
+/**
+@brief Checks if an element_id contains invalid characters. Returns true if
+element_id is valid and false if it is not.
+*/
 bool cstr_isvalid(const char *element_id);
 
+/**
+@brief Returns true if source is null terminated, otherwise it returns false.
+*/
 bool cstr_isnullterm(const char *source);
 
 


### PR DESCRIPTION
Addresses #186

This PR introduces a build and go batch file for epanet. It builds 32 bit and 64 bit versions of epanet. 

It requires installation of cmake and build tools for Visual Studio.  


Visual Studio downloads:
https://visualstudio.microsoft.com/downloads/

CMake download:
https://cmake.org/download/
