### PR TITLE
Lrossman dev

### DIFF
--- a/ReleaseNotes2_2.md
+++ b/ReleaseNotes2_2.md
@@ -84,11 +84,11 @@ Two new analysis options have been added to provide more rigorous convergence cr
 
 These new parameters augment the current `EN_ACCURACY` option which always remains in effect. In addition, both `EN_HEADERROR` and `EN_FLOWCHANGE` can be used as parameters in the `ENgetstatistic` (or `EN_getstatistic`) function to retrieve their computed values (even when their option values are 0) after a hydraulic solution has been completed.  
 
-## Improved Linear Solver Routine
+## More Efficient Node Re-ordering
 
 EPANET's hydraulic solver requires solving a system of linear equations over a series of iterations until a set of convergence criteria are met. The coefficient matrix of this linear system is square and symmetric. It has a row for each network node and a non-zero off-diagonal coefficient for each link. The numerical effort needed to solve the linear system can be reduced if the nodes are re-ordered so that the non-zero coefficients cluster more tightly around the diagonal.
 
-EPANET's original node re-ordering scheme has been replaced by the more powerful **Multiple Minimum Degree (MMD)** algorithm. On a series of eight networks ranging in size from 7,700 to 100,000 nodes **MMD** reduced the solution time for a single period (steady state) hydraulic analysis by an average of 58%.
+EPANET's original node re-ordering scheme has been replaced by the more efficient **Multiple Minimum Degree (MMD)** algorithm. On a series of eight networks ranging in size from 7,700 to 100,000 nodes MMD reduced the solution time for a single period (steady state) hydraulic analysis, where most of the work is for node-reordering, by an average of 55%. Since MMD did not reduce the time needed to solve the linear equations generated at each iteration of the hydraulic solver longer extended period simulations will not exhibit a similar speedup. 
 
 ## Improved Handling of Near-Zero Flows
 

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -9,7 +9,7 @@ The OWA-EPANET Toolkit is an open-source version of the original EPANET Toolkit 
 - allowing multiple projects to be analyzed in parallel in a thread-safe manner
 - adding the ability to use pressure dependent demands in hydraulic analyses
 - producing more robust results with regard to hydraulic convergence, low/zero flow conditions, and water quality mass balance
-- achieving faster run times for hydraulic analyses.
+- achieving faster run times for single period hydraulic analyses.
 
 Before using the OWA-EPANET Toolkit one should be familiar with the way that EPANET represents a pipe network, the design and operating information it requires, and the steps it uses to simulate a network's behavior. The following topics provide some introductory material on these subjects:
 - @subpage DataModel "Network Data Model"

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -1,5 +1,5 @@
 # EPANET COMMAND LINE EXECUTABLE
-cmake_minimum_required (VERSION 3.0.2)
+cmake_minimum_required (VERSION 2.8.8)
 
 
 # Sets for output directory for executables and libraries.

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -7,17 +7,11 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/25/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <float.h>

--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -7,16 +7,11 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 03/17/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+
+#include <stdlib.h>
 #include <string.h>
 
 #include "types.h"

--- a/src/epanet_py.c
+++ b/src/epanet_py.c
@@ -7,17 +7,11 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/08/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <string.h>
 
 #include "epanet_py.h"
@@ -27,12 +21,15 @@
 #include "types.h"
 
 
-typedef struct {
+typedef struct
+{
     Project *project;
     error_handle_t *error;
-}handle_t;
+} handle_t;
+
 // Extern functions
 extern char *geterrmsg(int, char *);
+
 // Local functions
 void error_lookup(int errcode, char *errmsg, int len);
 
@@ -782,7 +779,7 @@ int EXPORT_PY_API toolkit_getversion(int *version)
 
 void EXPORT_PY_API toolkit_free(void **memory)
 {
-	free(*memory);
+    free(*memory);
     *memory = NULL;
 }
 
@@ -790,6 +787,7 @@ void error_lookup(int errcode, char *dest_msg, int dest_len)
 // Purpose: takes error code returns error message
 {
     char *msg = NULL;
+    char new_msg[MAXMSG + 1];
 
     switch (errcode)
     {
@@ -805,11 +803,7 @@ void error_lookup(int errcode, char *dest_msg, int dest_len)
     break;
     case 6: msg = WARN6;
     break;
-    default:
-	{
-		char new_msg[MAXMSG + 1];
-		msg = geterrmsg(errcode, new_msg);
-	}
+    default: msg = geterrmsg(errcode, new_msg);
     }
     strncpy(dest_msg, msg, dest_len);
 }

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/18/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 #ifndef FUNCS_H

--- a/src/hash.c
+++ b/src/hash.c
@@ -7,17 +7,11 @@
   Authors:      see AUTHORS
   Copyright:    see AUTHORS
   License:      see LICENSE
-  Last Updated: 11/27/2018
+  Last Updated: 05/15/2019
  ******************************************************************************
  */
 
- #ifdef _DEBUG
-   #define _CRTDBG_MAP_ALLOC
-   #include <stdlib.h>
-   #include <crtdbg.h>
- #else
-   #include <stdlib.h>
- #endif
+#include <stdlib.h>
 #include <string.h>
 #include "hash.h"
 

--- a/src/hydcoeffs.c
+++ b/src/hydcoeffs.c
@@ -7,20 +7,13 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "types.h"
@@ -532,18 +525,18 @@ double demandflowchange(Project *pr, int i, double dp, double n)
 
 void demandheadloss(double d, double dfull, double dp, double n,
                     double *hloss, double *hgrad)
-    /*
-    **--------------------------------------------------------------
-    **   Input:   d     = actual junction demand (cfs)
-    **            dfull = full junction demand required (cfs)
-    **            dp    = pressure range for demand function (ft)
-    **            n     = exponent in head v. demand function
-    **   Output:  hloss = head loss delivering demand d (ft)
-    **            hgrad = gradient of head loss (ft/cfs)
-    **  Purpose:  computes head loss and its gradient for delivering
-    **            a pressure dependent demand flow.
-    **--------------------------------------------------------------
-    */
+/*
+**--------------------------------------------------------------
+**   Input:   d     = actual junction demand (cfs)
+**            dfull = full junction demand required (cfs)
+**            dp    = pressure range for demand function (ft)
+**            n     = exponent in head v. demand function
+**   Output:  hloss = head loss delivering demand d (ft)
+**            hgrad = gradient of head loss (ft/cfs)
+**  Purpose:  computes head loss and its gradient for delivering
+**            a pressure dependent demand flow.
+**--------------------------------------------------------------
+*/
 {
     const double RB = 1.0e9;
     const double EPS = 0.001;

--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -7,20 +7,13 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "types.h"

--- a/src/hydsolver.c
+++ b/src/hydsolver.c
@@ -8,20 +8,13 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "types.h"

--- a/src/hydstatus.c
+++ b/src/hydstatus.c
@@ -7,16 +7,11 @@ Description:  updates hydraulic status of network elements
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 05/15/2019
 ******************************************************************************
 */
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+
+#include <stdlib.h>
 #include <stdio.h>
 
 #include "types.h"

--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -7,27 +7,19 @@ Description:  saves network data to an EPANET formatted text file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 04/03/2019
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "types.h"
 #include "funcs.h"
 #include "hash.h"
 #include "text.h"
-
 
 // Defined in enumstxt.h in EPANET.C
 extern char *LinkTxt[];

--- a/src/input1.c
+++ b/src/input1.c
@@ -7,17 +7,11 @@ Description:  retrieves network data from an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 04/03/2019
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -26,7 +20,6 @@ Last Updated: 04/03/2019
 #include "funcs.h"
 #include "hash.h"
 #include "text.h"
-
 
 // Default values
 #define MAXITER  200  // Default max. # hydraulic iterations

--- a/src/input2.c
+++ b/src/input2.c
@@ -7,20 +7,13 @@ Description:  reads and interprets network data from an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 04/03/2019
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "types.h"

--- a/src/input3.c
+++ b/src/input3.c
@@ -7,17 +7,11 @@ Description:  parses network data from a line of an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 04/03/2019
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
@@ -703,7 +697,7 @@ int demanddata(Project *pr)
     int j, n, p = 0;
     double y;
 
-	Pdemand demand;
+    Pdemand demand;
 
     // Extract data from tokens
     n = parser->Ntokens;
@@ -866,7 +860,7 @@ int sourcedata(Project *pr)
 **  Purpose: processes water quality source data
 **  Formats:
 **     [SOURCE]
-**        node  sourcetype  quality  (pattern start stop)
+**        node  sourcetype  quality  (pattern)
 **
 **  NOTE: units of mass-based source are mass/min
 **--------------------------------------------------------------
@@ -934,7 +928,7 @@ int emitterdata(Project *pr)
 **  Purpose: processes junction emitter data
 **  Format:
 **     [EMITTER]
-**        node   K
+**        node   Ke
 **--------------------------------------------------------------
 */
 {
@@ -1674,7 +1668,7 @@ int optionchoice(Project *pr, int n)
 **    VERIFY              filename
 **    UNBALANCED          STOP/CONTINUE {Niter}
 **    PATTERN             id
-**    DEMAND MODEL        DDA/PDA/PPA
+**    DEMAND MODEL        DDA/PDA
 **--------------------------------------------------------------
 */
 {
@@ -1833,8 +1827,8 @@ int optionvalue(Project *pr, int n)
 **    TRIALS              value
 **    ACCURACY            value
 
-**    HEADLIMIT           value
-**    FLOWLIMIT           value
+**    HEADERROR           value
+**    FLOWCHANGE          value
 **    MINIMUM PRESSURE    value
 **    REQUIRED PRESSURE   value
 **    PRESSURE EXPONENT   value

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -7,20 +7,14 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 05/15/2019
 
  This module is based code by Steve Hill in Graphics Gems III,
  David Kirk (ed.), Academic Press, Boston, MA, 1992
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 #include "mempool.h"
 

--- a/src/output.c
+++ b/src/output.c
@@ -7,20 +7,13 @@ Description:  binary file read/write routines
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 05/13/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "types.h"

--- a/src/project.c
+++ b/src/project.c
@@ -7,17 +7,11 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/20/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/quality.c
+++ b/src/quality.c
@@ -7,20 +7,13 @@ Description:  implements EPANET's water quality engine
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 
 #include "mempool.h"

--- a/src/qualreact.c
+++ b/src/qualreact.c
@@ -7,17 +7,11 @@ Description:  computes water quality reactions within pipes and tanks
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
 #include "types.h"

--- a/src/qualroute.c
+++ b/src/qualroute.c
@@ -7,19 +7,12 @@ Description:  computes water quality transport over a single time step
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/27/2018
+Last Updated: 05/15/2019
 ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
-
 #include <math.h>
 
 #include "mempool.h"

--- a/src/report.c
+++ b/src/report.c
@@ -7,17 +7,11 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 03/05/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -7,17 +7,11 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/smatrix.c
+++ b/src/smatrix.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 11/27/2018
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 /*
@@ -18,16 +18,9 @@
    linsolve()     -- called from netsolve() in HYDRAUL.C
 */
 
-#ifdef _DEBUG
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
-#else
-  #include <stdlib.h>
-#endif
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
 #include <math.h>
 #include <limits.h>
 

--- a/src/types.h
+++ b/src/types.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/03/2019
+ Last Updated: 05/15/2019
  ******************************************************************************
 */
 
@@ -675,7 +675,6 @@ typedef struct {
     *XLNZ,       // Start position of each column in NZSUB
     *NZSUB,      // Row index of each coeff. in each column
     *LNZ,        // Position of each coeff. in Aij array
-    *Degree,     // Number of links adjacent to each node
     *link,       // Array used by linear eqn. solver
     *first;      // Array used by linear eqn. solver
 

--- a/src/types.h
+++ b/src/types.h
@@ -675,6 +675,7 @@ typedef struct {
     *XLNZ,       // Start position of each column in NZSUB
     *NZSUB,      // Row index of each coeff. in each column
     *LNZ,        // Position of each coeff. in Aij array
+    *Degree,     // Number of links adjacent to each node
     *link,       // Array used by linear eqn. solver
     *first;      // Array used by linear eqn. solver
 


### PR DESCRIPTION
This PR removes the `#ifdef _DEBUG` statements from all source files as per issue #482. It also makes minor updates to the doc files to emphasize that the speedup obtained by using MMD node re-ordering only applies to single period simulations.