### PR TITLE
Let the os handle temporary files

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -50,9 +50,9 @@ int DLLEXPORT EN_createproject(EN_Project *p)
 {
     struct Project *project = (struct Project *)calloc(1, sizeof(struct Project));
     if (project == NULL) return -1;
-    getTmpName(project->TmpHydFname);
-    getTmpName(project->TmpOutFname);
-    getTmpName(project->TmpStatFname);
+    //getTmpName(project->TmpHydFname);
+    //getTmpName(project->TmpOutFname);
+    //getTmpName(project->TmpStatFname);
     *p = project;
     return 0;
 }
@@ -68,9 +68,6 @@ int DLLEXPORT EN_deleteproject(EN_Project *p)
 {
     if (*p == NULL) return -1;
     if ((*p)->Openflag) EN_close(*p);
-    remove((*p)->TmpHydFname);
-    remove((*p)->TmpOutFname);
-    remove((*p)->TmpStatFname);
     free(*p);
     *p = NULL;
     return 0;
@@ -545,6 +542,7 @@ int DLLEXPORT EN_initH(EN_Project p, int initFlag)
     // Initialize hydraulics solver
     inithyd(p, fflag);
     if (p->report.Statflag > 0) writeheader(p, STATHDR, 0);
+ 
     return errcode;
 }
 

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -50,9 +50,6 @@ int DLLEXPORT EN_createproject(EN_Project *p)
 {
     struct Project *project = (struct Project *)calloc(1, sizeof(struct Project));
     if (project == NULL) return -1;
-    //getTmpName(project->TmpHydFname);
-    //getTmpName(project->TmpOutFname);
-    //getTmpName(project->TmpStatFname);
     *p = project;
     return 0;
 }

--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -31,22 +31,6 @@
 Project __defaultProject;
 Project *_defaultProject = &__defaultProject;
 
-// Functions for creating and removing default temporary files
-void createtmpfiles()
-{
-    getTmpName(_defaultProject->TmpHydFname);
-    getTmpName(_defaultProject->TmpOutFname);
-    getTmpName(_defaultProject->TmpStatFname);
-}
-
-void removetmpfiles()
-{
-    remove(_defaultProject->TmpHydFname);
-    remove(_defaultProject->TmpOutFname);
-    remove(_defaultProject->TmpStatFname);
-}
-
-
 /********************************************************************
 
     Project Functions
@@ -77,10 +61,8 @@ int DLLEXPORT ENepanet(const char *inpFile, const char *rptFile,
     int warncode = 0;
 
     // Run the project and record any warning
-    createtmpfiles();
     errcode = EN_runproject(_defaultProject, inpFile, rptFile, outFile, pviewprog);
     if (errcode < 100) warncode = errcode;
-    removetmpfiles();
 
     // Return the warning code if the run had no errors
     if (warncode) errcode = MAX(errcode, warncode);
@@ -91,7 +73,6 @@ int DLLEXPORT ENinit(const char *rptFile, const char *outFile, int unitsType,
                      int headlossType)
 {
     int errcode = 0;
-    createtmpfiles();
     errcode = EN_init(_defaultProject, rptFile, outFile, unitsType, headlossType);
     return errcode;
 }
@@ -99,7 +80,6 @@ int DLLEXPORT ENinit(const char *rptFile, const char *outFile, int unitsType,
 int DLLEXPORT ENopen(const char *inpFile, const char *rptFile, const char *outFile)
 {
     int errcode = 0;
-    createtmpfiles();
     errcode = EN_open(_defaultProject, inpFile, rptFile, outFile);
     return errcode;
 }
@@ -137,7 +117,6 @@ int DLLEXPORT ENsaveinpfile(const char *filename)
 int DLLEXPORT ENclose()
 {
     EN_close(_defaultProject);
-    removetmpfiles();
     return 0;
 }
 

--- a/src/project.c
+++ b/src/project.c
@@ -56,7 +56,6 @@ int openfiles(Project *pr, const char *f1, const char *f2, const char *f3)
     else
     {
         pr->outfile.Outflag = SCRATCH;
-        strcpy(pr->outfile.OutFname, pr->TmpOutFname);
     }
 
     // Check that file names are not identical
@@ -68,11 +67,17 @@ int openfiles(Project *pr, const char *f1, const char *f2, const char *f3)
     {
         if ((pr->parser.InFile = fopen(f1, "rt")) == NULL) return 302;
     }
-    if (strlen(f2) == 0) pr->report.RptFile = stdout;
+    if (strlen(f2) == 0) {
+        pr->report.RptFile = tmpfile();
+    }
     else
     {
+      if (strcomp(f2, "stdout")) {
+        pr->report.RptFile = stdout;
+      } else {
         pr->report.RptFile = fopen(f2, "wt");
-        if (pr->report.RptFile == NULL) return 303;
+      }
+      if (pr->report.RptFile == NULL) return 303;
     }
     writelogo(pr);
     return 0;
@@ -112,8 +117,7 @@ int openhydfile(Project *pr)
     switch (pr->outfile.Hydflag)
     {
       case SCRATCH:
-        strcpy(pr->outfile.HydFname, pr->TmpHydFname);
-        pr->outfile.HydFile = fopen(pr->outfile.HydFname, "w+b");
+        pr->outfile.HydFile = tmpfile();
         break;
       case SAVE:
         pr->outfile.HydFile = fopen(pr->outfile.HydFname, "w+b");
@@ -194,7 +198,7 @@ int openoutfile(Project *pr)
     {
         if (pr->report.Tstatflag != SERIES)
         {
-            pr->outfile.TmpOutFile = fopen(pr->TmpStatFname, "w+b");
+          pr->outfile.TmpOutFile = tmpfile();
             if (pr->outfile.TmpOutFile == NULL) errcode = 304;
         }
         else pr->outfile.TmpOutFile = pr->outfile.OutFile;


### PR DESCRIPTION
The littering of temporary scratch files generated by multiple instances running at the same time, or of improperly closed instances, were driving me nuts. I propose having the OS handle the creation and subsequent removal of scratch files using the ```tmpfile``` library function. 

A big advantage is that the scratch files get automatically removed, even if the process quits unexpectedly.