### PR TITLE
Fixes Overflow and PDA tests not being run

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,8 @@ set(toolkit_test_srcs
      test_pattern.cpp
      test_curve.cpp
      test_control.cpp
+     test_overflow.cpp
+     test_pda.cpp
 )
 
 add_executable(test_toolkit ${toolkit_test_srcs})

--- a/tests/test_pda.cpp
+++ b/tests/test_pda.cpp
@@ -21,7 +21,7 @@
 
 BOOST_AUTO_TEST_SUITE (test_pda)
 
-BOOST_AUTO_TEST_CASE(test_pda)
+BOOST_AUTO_TEST_CASE(test_pda_model)
 
 {
     int error = 0;


### PR DESCRIPTION
The most recently written unit tests for Tank Overflows and the PDA Demand Model were not being compiled nor run because their source files were never referenced in the CMakeLists script that builds the testing executable.