### PR TITLE
Add -MT switch for CMake Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ ENDIF (APPLE)
 
 IF (MSVC)
   set(CMAKE_C_FLAGS_RELEASE "/GL")
-  add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+  add_definitions(-D_CRT_SECURE_NO_DEPRECATE -MT)
 ENDIF (MSVC)
 
 # configure file groups

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -11,6 +11,12 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 
+# Link to multi-threaded static runtime library
+IF (MSVC)
+  add_definitions(-D_CRT_SECURE_NO_DEPRECATE -MT)
+ENDIF (MSVC)
+
+
 # Set up file groups for exe target
 set(EPANET_CLI_SOURCES main.c)
 include_directories(include)

--- a/src/outfile/CMakeLists.txt
+++ b/src/outfile/CMakeLists.txt
@@ -19,6 +19,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 
+# Disable deprecation & link to multi-threaded static runtime library
+IF (MSVC)
+  add_definitions(-D_CRT_SECURE_NO_DEPRECATE -MT)
+ENDIF (MSVC)
+
+
 # configure file groups
 set(EPANET_OUT_SOURCES  src/epanet_output.c
                        ../util/errormanager.c


### PR DESCRIPTION
This PR has CMake build the toolkit DLL and command line executable so they are statically linked to the MS Visual C++ runtime libraries.