### PR TITLE
Build script updates

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,20 +1,19 @@
-### How to Build OWA-EPANET
+The most straightforward way to build the EPANET files is by using `CMake` ([https://cmake.org/](https://cmake.org/)). `CMake` is a cross-platform build tool that generates platform native build systems that can be used with your compiler of choice. It uses a generator concept to represent different build tooling. `CMake` automatically detects the platform it is running on and generates the appropriate makefiles for the platform default compiler. Different generators can also be specified.
 
-The most straightforward way to build the OWA-EPANET project is by using `CMake` ([https://cmake.org/](https://cmake.org/)), a cross-platform build tool that generates platform native build systems that can be used with your compiler of choice. `CMake` uses a generator concept to represent different build tooling. It automatically detects the platform it is running on and generates the appropriate makefiles for the platform's default compiler. Different generators can also be specified.
-
-The project's `CMake` configuration file (`CMakeLists.txt`) is located in its root directory and supports builds for Linux, Mac OS and Windows. To build the EPANET library and its command line executable using `CMake`, first open a command prompt console window and navigate to the project's root directory. Then enter the following commands:
+The project's `CMake` file (`CMakeLists.txt`) is located in its root directory and supports builds for Linux, Mac OS and Windows. To build the EPANET library and its command line executable using `CMake`, first open a console window and navigate to the project's root directory. Then enter the following commands:
 ```
 mkdir build
 cd build
 cmake ..
 cmake --build . --config Release
 ```
-Note: Use `cmake -G "Visual Studio 15 2017 Win64" ..` as the third command for a 64-bit build on Windows.
 
-Under Windows the resulting EPANET toolkit library `epanet2.dll` and its command line executable `runepanet.exe` will be in the `build\bin\Release` directory. The `build\lib\Release` directory contains an `epanet2.lib` file which is needed to build C/C++ applications using the Windows version of the library. For Linux and Mac OS the EPANET toolkit shared library `libepanet2.so` appears in the `build/lib` directory and the command line executable `runepanet` is in the `build/bin` directory. 
+Note: under Windows, the third command should be `cmake .. -A Win32` for a 32-bit build or `cmake .. -A x64` for a 64-bit build when Microsoft Visual Studio is the default compiler.
 
-As an alternative to using `CMake` for a Windows build, two one-click-build scripts are included in the `win_build` directory:
-1. `Makefile2.bat`: this script requires both `CMake` and the build tools for Visual Studio (available from [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/) be installed on your machine. It can be executed from any command prompt window. The Community version of Visual Studio will work just fine. This script was tested with both Visual Studio 2017 and 2019.
-2. `Makefile.bat`: this build script uses only Visual Studio commands and does not require `CMake`. It is compatible with Visual Studio 2010 and higher and should be executed from a Visual Studio command prompt window.
+For Windows the resulting EPANET toolkit library `epanet2.dll` and its command line executable `runepanet.exe` are placed in the `build\bin\Release` directory. The `build\lib\Release` directory will contain an `epanet2.lib` file which is needed to build C/C++ applications using the Windows version of the library. For Linux and Mac OS the EPANET toolkit shared library `libepanet2.so` appears in the `build/lib` directory and the command line executable `runepanet` is in the `build/bin` directory. 
+
+In addition, two Windows one-click-build scripts are included in the `win_build` directory:
+1. `Makefile2.bat`: this script uses the `CMake` file and requires the build tools for Visual Studio available from [https://visualstudio.microsoft.com/downloads/](https://visualstudio.microsoft.com/downloads/). The Community version will work just fine. This script was tested with Visual Studio 2017 and 2019.
+2. `Makefile.bat`: this is the legacy build script compatible with Visual Studio 2010 which conforms with the C89 Standard which was the standard EPANET supported from earlier versions. This script requires the installation of Microsoft Windows SDK 7.1 ([https://www.microsoft.com/en-us/download/details.aspx?id=8279](https://www.microsoft.com/en-us/download/details.aspx?id=8279)) and will probably not run correctly on later versions of the SDK. `CMake` is not used in this script.
  
-Both scripts will build the EPANET library and the command line executable for the 32 and 64 bit Windows platforms, placing them in the `win_build\32bit` and `win_build\64bit` directories, respectively.
+These two scripts build EPANET binaries for both the 32 and 64 bit Windows platforms, placing them in the `win_build\32bit` and `win_build\64bit` directories, respectively.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ IF (BUILD_TESTS)
 ENDIF (BUILD_TESTS)
 
 
-# Sets for output directory for executables and libraries.
+# Sets the output directory for executables and libraries.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -89,11 +89,14 @@ list(REMOVE_ITEM EPANET_LIB_ALL "src/epanet_py.c")
 source_group("Library" FILES ${EPANET_LIB_ALL})
 
 # the shared library
-IF("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" OR NOT MSVC)
-  add_library(epanet2 SHARED ${EPANET_LIB_ALL})
-ELSE(TRUE)
+IF(MSVC AND "${CMAKE_VS_PLATFORM_NAME}" MATCHES "(Win32)")
+  message("   ************************************")
+  message("   Configuring with epanet2.def mapping")
+  message("   ************************************")
   add_library(epanet2 SHARED ${EPANET_LIB_ALL} ${PROJECT_SOURCE_DIR}/include/epanet2.def)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/include/epanet2.def PROPERTIES_HEADER_FILE_ONLY TRUE)
-ENDIF("${CMAKE_GENERATOR}" MATCHES "(Win64|IA64)" OR NOT MSVC)
+ELSE(TRUE)
+  add_library(epanet2 SHARED ${EPANET_LIB_ALL})
+ENDIF(MSVC AND "${CMAKE_VS_PLATFORM_NAME}" MATCHES "(Win32)")
 
 target_include_directories(epanet2 PUBLIC ${PROJECT_SOURCE_DIR}/include)

--- a/win_build/Makefile2.bat
+++ b/win_build/Makefile2.bat
@@ -5,45 +5,38 @@ SET CMAKE_PATH=cmake.exe
 
 SET Build_PATH=%CD%
 
-rem : set genarator
-SET GENERATOR=Visual Studio 15 2017
-
 rem : the directory where the program will be compiled to
-SET COMPILE_PATH_WIN64TMP=%Build_PATH%\tmp64\
+SET COMPILE_PATH_TMP=%Build_PATH%\tmp\
 SET COMPILE_PATH_WIN64=%Build_PATH%\64bit\
-
-rem : the directory where the program will be compiled to
-SET COMPILE_PATH_WIN32TMP=%Build_PATH%\tmp32\
 SET COMPILE_PATH_WIN32=%Build_PATH%\32bit\
 
 rem : CMAKE the root directory of the EPANET project 
-rem : 64 bit
-MKDIR "%COMPILE_PATH_WIN64TMP%"
-CD "%COMPILE_PATH_WIN64TMP%"
-MKDIR "%COMPILE_PATH_WIN64%"
-%CMAKE_PATH% -G "%GENERATOR% Win64" ../../
-rem : %CMAKE_PATH% --build . --config Debug
-%CMAKE_PATH% --build . --config Release
-
-XCOPY "%COMPILE_PATH_WIN64TMP%bin\Release\epanet2.dll" "%COMPILE_PATH_WIN64%epanet2.dll*" /y
-XCOPY "%COMPILE_PATH_WIN64TMP%bin\Release\runepanet.exe" "%COMPILE_PATH_WIN64%runepanet.exe*" /y
-XCOPY "%COMPILE_PATH_WIN64TMP%lib\Release\epanet2.lib" "%COMPILE_PATH_WIN64%epanet2.lib*" /y
-
-rem : CMAKE the root directory of the EPANET project 
 rem : 32 bit
-MKDIR "%COMPILE_PATH_WIN32TMP%"
-CD "%COMPILE_PATH_WIN32TMP%"
-MKDIR "%COMPILE_PATH_WIN32%"
-%CMAKE_PATH% -G "%GENERATOR%" ../../
-rem : %CMAKE_PATH% --build . --config Debug
+MKDIR "%COMPILE_PATH_TMP%"
+CD "%COMPILE_PATH_TMP%"
+%CMAKE_PATH% ../../ -A Win32
 %CMAKE_PATH% --build . --config Release
 
-XCOPY "%COMPILE_PATH_WIN32TMP%bin\Release\epanet2.dll" "%COMPILE_PATH_WIN32%epanet2.dll*" /y
-XCOPY "%COMPILE_PATH_WIN32TMP%bin\Release\runepanet.exe" "%COMPILE_PATH_WIN32%runepanet.exe*" /y
-XCOPY "%COMPILE_PATH_WIN32TMP%lib\Release\epanet2.lib" "%COMPILE_PATH_WIN32%epanet2.lib*" /y
+MKDIR "%COMPILE_PATH_WIN32%"
+XCOPY "%COMPILE_PATH_TMP%bin\Release\epanet2.dll" "%COMPILE_PATH_WIN32%epanet2.dll*" /y
+XCOPY "%COMPILE_PATH_TMP%bin\Release\runepanet.exe" "%COMPILE_PATH_WIN32%runepanet.exe*" /y
+XCOPY "%COMPILE_PATH_TMP%lib\Release\epanet2.lib" "%COMPILE_PATH_WIN32%epanet2.lib*" /y
 
 CD "%Build_PATH%"
+RMDIR /s /q "%COMPILE_PATH_TMP%"
 
-rem : cleaning
-RMDIR /s /q "%COMPILE_PATH_WIN64TMP%"
-RMDIR /s /q "%COMPILE_PATH_WIN32TMP%"
+rem : CMAKE the root directory of the EPANET project 
+rem : 64 bit
+MKDIR "%COMPILE_PATH_TMP%"
+CD "%COMPILE_PATH_TMP%"
+%CMAKE_PATH% ../../ -A x64
+%CMAKE_PATH% --build . --config Release
+
+MKDIR "%COMPILE_PATH_WIN64%"
+XCOPY "%COMPILE_PATH_TMP%bin\Release\epanet2.dll" "%COMPILE_PATH_WIN64%epanet2.dll*" /y
+XCOPY "%COMPILE_PATH_TMP%bin\Release\runepanet.exe" "%COMPILE_PATH_WIN64%runepanet.exe*" /y
+XCOPY "%COMPILE_PATH_TMP%lib\Release\epanet2.lib" "%COMPILE_PATH_WIN64%epanet2.lib*" /y
+
+CD "%Build_PATH%"
+RMDIR /s /q "%COMPILE_PATH_TMP%"
+


### PR DESCRIPTION
The CMakeLists.txt and Makefile2.bat scripts were modified to work correctly with Visual Studio 2019 and with CMake's -A switch to specify which windows platform (Win32 or x64) to build for.