### PR TITLE
fixes use of mkstemp and associated file-descriptor-leaking behavior

### DIFF
--- a/src/project.c
+++ b/src/project.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 //*** For the Windows SDK _tempnam function ***//
 #ifdef _WIN32
@@ -1091,8 +1092,11 @@ char *getTmpName(char *fname)
     // --- for non-Windows systems:
 #else
     // --- use system function mkstemp() to create a temporary file name
+    int f = -1;
     strcpy(fname, "enXXXXXX");
-    mkstemp(fname);
+    f = mkstemp(fname);
+    close(f);
+    remove(fname);
 #endif
     return fname;
 }


### PR DESCRIPTION
I was pretty surprised to find this behavior - but it showed up while running lots of independent simulations serially under the same process - the OS (Mac/*nix) said it reached the open-file limit.  Investigation revealed that `mkstemp` returns a file descriptor ready for r/w - even though epanet later opens this file under a different handle, closes the second handle, and removes the file - without closing the (leaked) descriptor.

This workaround uses `mkstemp` to only create the file name from the template provided. The temp file created is closed and unlinked.