### PR TITLE
Incorrect character causing a LaTeX compilation problem

### DIFF
--- a/doc/input-file.dox
+++ b/doc/input-file.dox
@@ -1068,7 +1068,7 @@ bounding rectangle. Defaults are the extents of the nodal coordinates supplied i
 <b>FILE</b> supplies the name of the file that contains a backdrop image for the network.
 
 <b>OFFSET</b> lists the X and Y distance that the upper-left corner of the backdrop image is offset from the
-upper-left corner of the network’s bounding rectangle. Default is zero offset.
+upper-left corner of the network's bounding rectangle. Default is zero offset.
 
 __Remarks:__
 


### PR DESCRIPTION
There was a character ’ instead of ' which created an error when compiling LaTeX.