### PR TITLE
Allow start time to be set with EN_settimeparam

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1591,6 +1591,11 @@ int DLLEXPORT EN_settimeparam(EN_Project p, int param, long value)
         time->Qtime = value;
         break;
 
+    case EN_STARTTIME:
+        if (value < 0) return 213;
+	    time->Tstart = value;
+        break;
+
     default:
         return 251;
     }

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1592,7 +1592,7 @@ int DLLEXPORT EN_settimeparam(EN_Project p, int param, long value)
         break;
 
     case EN_STARTTIME:
-        if (value < 0) return 213;
+        if (value < 0 || value > SECperDAY) return 213;
 	    time->Tstart = value;
         break;
 


### PR DESCRIPTION
The EN_settimeparam function in the v2.2 toolkit API can be used to set time parameters; however, it does not allow the start time (EN_STARTTIME) to be set. This pull request adds an additional case to enable the start time to be set.

Closes #588 