### PR TITLE
Fix use-after-free in Smatrix, test_pda

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1777,6 +1777,8 @@ int DLLEXPORT EN_addnode(EN_Project p, char *id, int nodeType, int *index)
     hyd->NodeDemand = (double *)realloc(hyd->NodeDemand, size);
     qual->NodeQual = (double *)realloc(qual->NodeQual, size);
     hyd->NodeHead = (double *)realloc(hyd->NodeHead, size);
+    hyd->DemandFlow = (double *)realloc(hyd->DemandFlow, size);
+    hyd->EmitterFlow = (double *)realloc(hyd->EmitterFlow, size);
 
     // Actions taken when a new Junction is added
     if (nodeType == EN_JUNCTION)

--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -305,16 +305,12 @@ int  allocmatrix(Project *pr)
 
     hyd->P   = (double *) calloc(net->Nlinks+1,sizeof(double));
     hyd->Y   = (double *) calloc(net->Nlinks+1,sizeof(double));
-    hyd->DemandFlow = (double *) calloc(net->Nnodes + 1, sizeof(double));
-    hyd->EmitterFlow = (double *) calloc(net->Nnodes+1, sizeof(double));
     hyd->Xflow = (double *) calloc(MAX((net->Nnodes+1), (net->Nlinks+1)),
                                    sizeof(double));
     hyd->OldStatus = (StatusType *) calloc(net->Nlinks+net->Ntanks+1,
                                            sizeof(StatusType));
     ERRCODE(MEMCHECK(hyd->P));
     ERRCODE(MEMCHECK(hyd->Y));
-    ERRCODE(MEMCHECK(hyd->DemandFlow));
-    ERRCODE(MEMCHECK(hyd->EmitterFlow));
     ERRCODE(MEMCHECK(hyd->Xflow));
     ERRCODE(MEMCHECK(hyd->OldStatus));
     return errcode;
@@ -334,8 +330,6 @@ void  freematrix(Project *pr)
 
     free(hyd->P);
     free(hyd->Y);
-    free(hyd->DemandFlow);
-    free(hyd->EmitterFlow);
     free(hyd->Xflow);
     free(hyd->OldStatus);
 }

--- a/src/project.c
+++ b/src/project.c
@@ -253,6 +253,8 @@ void initpointers(Project *pr)
     pr->hydraul.P = NULL;
     pr->hydraul.Y = NULL;
     pr->hydraul.Xflow = NULL;
+    pr->hydraul.DemandFlow = NULL;
+    pr->hydraul.EmitterFlow = NULL;
 
     pr->quality.NodeQual = NULL;
     pr->quality.PipeRateCoeff = NULL;

--- a/src/project.c
+++ b/src/project.c
@@ -313,10 +313,14 @@ int allocdata(Project *pr)
         pr->hydraul.NodeDemand = (double *)calloc(n, sizeof(double));
         pr->hydraul.NodeHead   = (double *)calloc(n, sizeof(double));
         pr->quality.NodeQual   = (double *)calloc(n, sizeof(double));
+        pr->hydraul.DemandFlow  = (double *)calloc(n, sizeof(double));
+        pr->hydraul.EmitterFlow = (double *)calloc(n, sizeof(double));
         ERRCODE(MEMCHECK(pr->network.Node));
         ERRCODE(MEMCHECK(pr->hydraul.NodeDemand));
         ERRCODE(MEMCHECK(pr->hydraul.NodeHead));
         ERRCODE(MEMCHECK(pr->quality.NodeQual));
+        ERRCODE(MEMCHECK(pr->hydraul.DemandFlow));
+        ERRCODE(MEMCHECK(pr->hydraul.EmitterFlow));
     }
 
     // Allocate memory for network links
@@ -388,6 +392,8 @@ void freedata(Project *pr)
     free(pr->hydraul.LinkFlow);
     free(pr->hydraul.LinkSetting);
     free(pr->hydraul.LinkStatus);
+    free(pr->hydraul.DemandFlow);
+    free(pr->hydraul.EmitterFlow);
     free(pr->quality.NodeQual);
 
     // Free memory used for nodal adjacency lists

--- a/src/types.h
+++ b/src/types.h
@@ -688,7 +688,6 @@ typedef struct {
     *XLNZ,       // Start position of each column in NZSUB
     *NZSUB,      // Row index of each coeff. in each column
     *LNZ,        // Position of each coeff. in Aij array
-    *Degree,     // Number of links adjacent to each node
     *link,       // Array used by linear eqn. solver
     *first;      // Array used by linear eqn. solver
 


### PR DESCRIPTION
`Smatrix` allocates and frees `sm->Degree` inside of `factorize()`, but uses it in `growlist()` where it is no longer valid.

I move the allocate `sm->Degree` to `allocsmatrix()` where we already have `Nnodes`, and the free to `freesparse()` where everything else in `Smatrix` is being free'd.

---

In test_pda.cpp, `EN_getnodevalue(EN_DEMANDDEFICIT)` reads from three members of hyd (`DemandFlow`, `NodeDemand`, `EmitterFlow`) however two of these members (`DemandFlow`, `EmitterFlow`) are only valid between `EN_openH` and `EN_closeH`, which are both called in `EN_solveH`.

I add `EN_solve_openedH`, implement `EN_solveH` in terms of it, and call it instead in test_pda.cpp

I'm not sure whether this is the best way forward for this issue, though. It would make more sense to me to do away with `EN_openH` and `EN_closeH` (or keep them around, nonfunctional, for ABI compatibility) and perform their functionality in `EN_open` / `EN_close`.