### PR TITLE
Dev issue #532

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 # Doxygen output
 doxygen_out/
 
+# Test network
+test-network/
+
 # OS X Finder
 .DS_Store
 

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -95,7 +95,8 @@ typedef enum {
   EN_PUMP_ECURVE  = 20,   //!< Pump efficiency v. flow curve index
   EN_PUMP_ECOST   = 21,   //!< Pump average energy price
   EN_PUMP_EPAT    = 22,   //!< Pump energy price time pattern index
-  EN_PUMP_GROUPCOUNT = 23 //!<Number of pumps in parallel in the pump object
+  EN_PUMP_GROUPCOUNT = 23, //!<Number of pumps in parallel in the pump object
+  EN_LINK_INCONTROL = 24   //!< Link appears in any simple or rule-based control (= 1) or not (= 0)
 } EN_LinkProperty;
 
 /// Time parameters

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -72,29 +72,30 @@ These link properties are used with @ref EN_getlinkvalue and @ref EN_setlinkvalu
 Those marked as read only are computed values that can only be retrieved.
 */
 typedef enum {
-  EN_DIAMETER     = 0,  //!< Pipe/valve diameter
-  EN_LENGTH       = 1,  //!< Pipe length
-  EN_ROUGHNESS    = 2,  //!< Pipe roughness coefficient
-  EN_MINORLOSS    = 3,  //!< Pipe/valve minor loss coefficient
-  EN_INITSTATUS   = 4,  //!< Initial status (see @ref EN_LinkStatusType)
-  EN_INITSETTING  = 5,  //!< Initial pump speed or valve setting
-  EN_KBULK        = 6,  //!< Bulk chemical reaction coefficient
-  EN_KWALL        = 7,  //!< Pipe wall chemical reaction coefficient
-  EN_FLOW         = 8,  //!< Current computed flow rate (read only)
-  EN_VELOCITY     = 9,  //!< Current computed flow velocity (read only)
-  EN_HEADLOSS     = 10, //!< Current computed head loss (read only)
-  EN_STATUS       = 11, //!< Current link status (see @ref EN_LinkStatusType)
-  EN_SETTING      = 12, //!< Current link setting
-  EN_ENERGY       = 13, //!< Current computed pump energy usage (read only)
-  EN_LINKQUAL     = 14, //!< Current computed link quality (read only)
-  EN_LINKPATTERN  = 15, //!< Pump speed time pattern index
-  EN_PUMP_STATE   = 16, //!< Current computed pump state (read only) (see @ref EN_PumpStateType)
-  EN_PUMP_EFFIC   = 17, //!< Current computed pump efficiency (read only)
-  EN_PUMP_POWER   = 18, //!< Pump constant power rating
-  EN_PUMP_HCURVE  = 19, //!< Pump head v. flow curve index
-  EN_PUMP_ECURVE  = 20, //!< Pump efficiency v. flow curve index
-  EN_PUMP_ECOST   = 21, //!< Pump average energy price
-  EN_PUMP_EPAT    = 22  //!< Pump energy price time pattern index
+  EN_DIAMETER     = 0,    //!< Pipe/valve diameter
+  EN_LENGTH       = 1,    //!< Pipe length
+  EN_ROUGHNESS    = 2,    //!< Pipe roughness coefficient
+  EN_MINORLOSS    = 3,    //!< Pipe/valve minor loss coefficient
+  EN_INITSTATUS   = 4,    //!< Initial status (see @ref EN_LinkStatusType)
+  EN_INITSETTING  = 5,    //!< Initial pump speed or valve setting
+  EN_KBULK        = 6,    //!< Bulk chemical reaction coefficient
+  EN_KWALL        = 7,    //!< Pipe wall chemical reaction coefficient
+  EN_FLOW         = 8,    //!< Current computed flow rate (read only)
+  EN_VELOCITY     = 9,    //!< Current computed flow velocity (read only)
+  EN_HEADLOSS     = 10,   //!< Current computed head loss (read only)
+  EN_STATUS       = 11,   //!< Current link status (see @ref EN_LinkStatusType)
+  EN_SETTING      = 12,   //!< Current link setting
+  EN_ENERGY       = 13,   //!< Current computed pump energy usage (read only)
+  EN_LINKQUAL     = 14,   //!< Current computed link quality (read only)
+  EN_LINKPATTERN  = 15,   //!< Pump speed time pattern index
+  EN_PUMP_STATE   = 16,   //!< Current computed pump state (read only) (see @ref EN_PumpStateType)
+  EN_PUMP_EFFIC   = 17,   //!< Current computed pump efficiency (read only)
+  EN_PUMP_POWER   = 18,   //!< Pump constant power rating
+  EN_PUMP_HCURVE  = 19,   //!< Pump head v. flow curve index
+  EN_PUMP_ECURVE  = 20,   //!< Pump efficiency v. flow curve index
+  EN_PUMP_ECOST   = 21,   //!< Pump average energy price
+  EN_PUMP_EPAT    = 22,   //!< Pump energy price time pattern index
+  EN_PUMP_GROUPCOUNT = 23 //!<Number of pumps in parallel in the pump object
 } EN_LinkProperty;
 
 /// Time parameters

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -98,31 +98,6 @@ typedef enum {
   EN_PUMP_EPAT    = 22,   //!< Pump energy price time pattern index
   EN_LINK_INCONTROL = 23, //!< Is present in any simple or rule-based control (= 1) or not (= 0)
   EN_PUMP_GROUPCOUNT = 24 //!<Number of pumps in parallel in the pump object
-=======
-  EN_DIAMETER     = 0,  //!< Pipe/valve diameter
-  EN_LENGTH       = 1,  //!< Pipe length
-  EN_ROUGHNESS    = 2,  //!< Pipe roughness coefficient
-  EN_MINORLOSS    = 3,  //!< Pipe/valve minor loss coefficient
-  EN_INITSTATUS   = 4,  //!< Initial status (see @ref EN_LinkStatusType)
-  EN_INITSETTING  = 5,  //!< Initial pump speed or valve setting
-  EN_KBULK        = 6,  //!< Bulk chemical reaction coefficient
-  EN_KWALL        = 7,  //!< Pipe wall chemical reaction coefficient
-  EN_FLOW         = 8,  //!< Current computed flow rate (read only)
-  EN_VELOCITY     = 9,  //!< Current computed flow velocity (read only)
-  EN_HEADLOSS     = 10, //!< Current computed head loss (read only)
-  EN_STATUS       = 11, //!< Current link status (see @ref EN_LinkStatusType)
-  EN_SETTING      = 12, //!< Current link setting
-  EN_ENERGY       = 13, //!< Current computed pump energy usage (read only)
-  EN_LINKQUAL     = 14, //!< Current computed link quality (read only)
-  EN_LINKPATTERN  = 15, //!< Pump speed time pattern index
-  EN_PUMP_STATE   = 16, //!< Current computed pump state (read only) (see @ref EN_PumpStateType)
-  EN_PUMP_EFFIC   = 17, //!< Current computed pump efficiency (read only)
-  EN_PUMP_POWER   = 18, //!< Pump constant power rating
-  EN_PUMP_HCURVE  = 19, //!< Pump head v. flow curve index
-  EN_PUMP_ECURVE  = 20, //!< Pump efficiency v. flow curve index
-  EN_PUMP_ECOST   = 21, //!< Pump average energy price
-  EN_PUMP_EPAT    = 22, //!< Pump energy price time pattern index
-  EN_LINK_INCONTROL = 23  //!< Is present in any simple or rule-based control (= 1) or not (= 0)
 } EN_LinkProperty;
 
 /// Time parameters

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -3180,6 +3180,7 @@ int DLLEXPORT EN_addlink(EN_Project p, char *id, int linkType,
         size = (net->Npumps + 1) * sizeof(Spump);
         net->Pump = (Spump *)realloc(net->Pump, size);
         pump = &net->Pump[net->Npumps];
+        pump->GroupCount = 1;
         pump->Link = n;
         pump->Ptype = NOCURVE;
         pump->Q0 = 0;
@@ -3784,6 +3785,13 @@ int DLLEXPORT EN_getlinkvalue(EN_Project p, int index, int property, double *val
             v = (double)Pump[findpump(&p->network, index)].Epat;
         }
         break;
+        
+    case EN_PUMP_GROUPCOUNT:
+    	if (Link[index].Type == PUMP)
+    	{
+    	    v = (double)Pump[findpump(&p->network, index)].GroupCount;
+    	}
+    	break;
 
     default:
         return 251;
@@ -3812,7 +3820,7 @@ int DLLEXPORT EN_setlinkvalue(EN_Project p, int index, int property, double valu
     double *LinkSetting = hyd->LinkSetting;
     char s;
     double r;
-    int pumpIndex, patIndex, curveIndex;
+    int pumpIndex, patIndex, curveIndex, pumpGroupCount;
 
     if (!p->Openflag) return 102;
     if (index <= 0 || index > net->Nlinks) return 204;
@@ -3991,7 +3999,17 @@ int DLLEXPORT EN_setlinkvalue(EN_Project p, int index, int property, double valu
             net->Pump[pumpIndex].Epat = patIndex;
         }
         break;
-
+    
+    case EN_PUMP_GROUPCOUNT:
+    	if (Link[index].Type == PUMP)
+    	{
+    	    pumpGroupCount = ROUND(value);
+    	    if (pumpGroupCount < 1) return 211;
+            pumpIndex = findpump(&p->network, index);
+            net->Pump[pumpIndex].GroupCount = pumpGroupCount;    	    
+    	}
+    	break;
+    
     default:
         return 251;
     }

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -3736,7 +3736,7 @@ int DLLEXPORT EN_getlinkvalue(EN_Project p, int index, int property, double *val
             pmp = findpump(net, index);
             if (hyd->LinkStatus[index] >= OPEN)
             {
-                if (hyd->LinkFlow[index] > hyd->LinkSetting[index] * Pump[pmp].Qmax)
+                if (hyd->LinkFlow[index] > hyd->LinkSetting[index] * Pump[pmp].Qmax * Pump[pmp].GroupCount)
                 {
                     v = XFLOW;
                 }

--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -351,9 +351,9 @@ void  initlinkflow(Project *pr, int i, char s, double k)
 */
 {
     Hydraul *hyd = &pr->hydraul;
-    Network *n = &pr->network;
+    Network *net = &pr->network;
 
-    Slink *link = &n->Link[i];
+    Slink *link = &net->Link[i];
     Spump *pump;
 
     if (s == CLOSED)

--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -365,7 +365,16 @@ void  initlinkflow(Project *pr, int i, char s, double k)
     }
     else if (link->Type == PUMP)
     {
-        hyd->LinkFlow[i] = k * n->Pump[findpump(n,i)].Q0;
+        if(n->Pump[findpump(n,i)].Ptype == CONST_HP)
+        {
+            hyd->LinkFlow[i] = k * (n->Pump[findpump(n,i)].Q0);
+        }
+        else
+        {
+            /* Design flow for a group of pumps is equal to pump speed * pump's design flow * 
+            number of pumps in a group */
+            hyd->LinkFlow[i] = k * (n->Pump[findpump(n,i)].Q0)*(n->Pump[findpump(n,i)].GroupCount);
+        }
     }
     else
     {

--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -269,6 +269,13 @@ int saveinpfile(Project *pr, const char *fname)
             sprintf(s1, "  SPEED %.4f", link->Kc);
             strcat(s, s1);
         }
+        
+        // Optional GroupCount setting
+        if (pump->GroupCount > 1)
+        {
+            sprintf(s1, "  GROUPCOUNT %d", pump->GroupCount);
+            strcat(s, s1);
+        }
 
         fprintf(f, "\n%s", s);
         if (link->Comment) fprintf(f, "  ;%s", link->Comment);

--- a/src/input3.c
+++ b/src/input3.c
@@ -356,7 +356,7 @@ int pumpdata(Project *pr)
 **   id  node1  node2  h0    h1   q1   h2   q2
 **   (Version 2 Format):
 **   id  node1  node2  KEYWORD value {KEYWORD value ...}
-**   where KEYWORD = [POWER,HEAD,PATTERN,SPEED]
+**   where KEYWORD = [POWER,HEAD,PATTERN,SPEED,GROUPCOUNT]
 **--------------------------------------------------------------
 */
 {
@@ -457,6 +457,13 @@ int pumpdata(Project *pr)
             if (!getfloat(parser->Tok[m], &y)) return setError(parser, m, 202);
             if (y < 0.0) return setError(parser, m, 211);
             link->Kc = y;
+        }
+        
+        else if (match(parser->Tok[m - 1], w_GROUPCOUNT)) // Pump group count setting
+        {
+            if (!getfloat(parser->Tok[m], &y)) return setError(parser, m, 202);
+            if (y < 1.0) return setError(parser, m, 211);
+            pump->GroupCount = y;
         }
         else return 201;
         m = m + 2;  // Move to next keyword token

--- a/src/input3.c
+++ b/src/input3.c
@@ -412,6 +412,7 @@ int pumpdata(Project *pr)
     pump->Upat = 0;
     pump->Ecost = 0.0;
     pump->Epat = 0;
+    pump->GroupCount = 1;
     if (n < 4) return 0;
 
     // If 4-th token is a number then input follows Version 1.x format

--- a/src/input3.c
+++ b/src/input3.c
@@ -463,7 +463,7 @@ int pumpdata(Project *pr)
         {
             if (!getfloat(parser->Tok[m], &y)) return setError(parser, m, 202);
             if (y < 1.0) return setError(parser, m, 211);
-            pump->GroupCount = y;
+            pump->GroupCount = ROUND(y);
         }
         else return 201;
         m = m + 2;  // Move to next keyword token

--- a/src/text.h
+++ b/src/text.h
@@ -169,6 +169,7 @@
 #define   w_HEAD        "HEAD"
 #define   w_POWER       "POWER"
 #define   w_SPEED       "SPEE"
+#define   w_GROUPCOUNT  "GROUPCOUNT"
 
 #define   w_MIXED       "MIXED"
 #define   w_2COMP       "2COMP"

--- a/src/types.h
+++ b/src/types.h
@@ -434,6 +434,7 @@ typedef struct             // Tank Object
 
 typedef struct             // Pump Object
 {
+  int     GroupCount;      // number of identical pumps in a pump group
   int     Link;            // link index of pump
   int     Ptype;           // pump curve type
   double  Q0;              // initial flow


### PR DESCRIPTION
This commit solves issue #532 to allow modelling the power consumption of a number of parallel identical pumps (specified by the integer variable `GroupCount` in the pump object `SPump` operating at different relative speeds `s` following the approach given by @LRossman. The code was tested on a simple network with the topology shown below.
![4](https://user-images.githubusercontent.com/8837107/83304570-60252180-a1ff-11ea-868e-a87c0c7d0a2a.png)
The pump characteristics were measured by recording pressure heads in nodes `R1` and `J1` for different values of demands set in node `J1`.
The network was simulated with one pump and two pumps in parallel operating with `s=1.0` and `s=0.75` respectively. The results form OWA EPANET (marked as points) were compared against calculations "by hand" in MATLAB/OCTAVE (marked with lines). 
First, the scaling of pump curves was tested for the pump type: `EN_CUSTOM` and `EN_POWER_FUNC` respectively (please see the results below)
![9](https://user-images.githubusercontent.com/8837107/83305616-63b9a800-a201-11ea-8706-bb4246fb5b56.png)
![10](https://user-images.githubusercontent.com/8837107/83305620-67e5c580-a201-11ea-9afd-628f7bf1a949.png)
Second, we tested the efficiency curve scaling and power consumption where the efficiency curve of a single pump operating at `s=1` is described with an interpolated curve (multipoint) and analytical third order approximation function with coefficients calculated with Eq.8 in B. Ulanicki, J. Kahler, and B. Coulbeck, “[Modeling the Efficiency and Power Characteristics of a Pump Group](https://ascelibrary.org/doi/10.1061/%28ASCE%290733-9496%282008%29134%3A1%2888%29),” Journal of Water Resources Planning and Management, vol. 134,no. 1, pp. 88–93, February 2008.
The results are shown in the figures below.
![3](https://user-images.githubusercontent.com/8837107/83308936-36bcc380-a208-11ea-9bf0-9005c85a7ee9.png)
![2](https://user-images.githubusercontent.com/8837107/83308942-3c1a0e00-a208-11ea-9309-00bec59a2084.png)
![8](https://user-images.githubusercontent.com/8837107/83308963-4a682a00-a208-11ea-8a05-a63bc04713f8.png)
![5](https://user-images.githubusercontent.com/8837107/83308969-4dfbb100-a208-11ea-8237-6c4b6b1f3e0a.png)
**Note:** We can sometimes see slight mismatches for some points in plots where the efficiency curve in OWA EPANET was interpolated. The reason for this is that for cross-testing interpolation was not modelled in OCTAVE and instead, the curves in OCTAVE were calculated using an analytical function. The mismatches arises in points where the interpolated efficiency is different to efficiency calculated from the analytical function.
Finally, scaling was also tested for a global constant efficiency (for a single pump) eta = 0.75
![7](https://user-images.githubusercontent.com/8837107/83309651-1c83e500-a20a-11ea-985b-6b32b364aced.png)


