### PR TITLE
Fix Unconnected nodes garbled error message 

### DIFF
--- a/src/errors.dat
+++ b/src/errors.dat
@@ -44,6 +44,7 @@ DAT(226,"no head curve or power rating for pump")
 DAT(227,"invalid head curve for pump")
 DAT(230,"nonincreasing x-values for curve")
 DAT(233,"network has unconnected nodes")
+DAT(2331,"network has an unconnected node with ID: ")
 
 // These errors apply only to API functions
 DAT(240,"nonexistent source")

--- a/src/errors.dat
+++ b/src/errors.dat
@@ -44,7 +44,7 @@ DAT(226,"no head curve or power rating for pump")
 DAT(227,"invalid head curve for pump")
 DAT(230,"nonincreasing x-values for curve")
 DAT(233,"network has unconnected nodes")
-DAT(2331,"network has an unconnected node with ID: ")
+DAT(234,"network has an unconnected node with ID: ")
 
 // These errors apply only to API functions
 DAT(240,"nonexistent source")

--- a/src/input2.c
+++ b/src/input2.c
@@ -146,6 +146,7 @@ int readdata(Project *pr)
 
     char line[MAXLINE + 1],  // Line from input data file
          wline[MAXLINE + 1]; // Working copy of input line
+	char errmsg[MAXMSG + 1] = "";		 
     int  sect, newsect,      // Data sections
          errcode = 0,        // Error code
          inperr, errsum;     // Error code & total error count
@@ -207,7 +208,7 @@ int readdata(Project *pr)
         // Check if max. line length exceeded
         if (strlen(line) >= MAXLINE)
         {
-            sprintf(pr->Msg, "%s section: %s", geterrmsg(214, pr->Msg), SectTxt[sect]);
+            sprintf(pr->Msg, "%s section: %s", geterrmsg(214, errmsg), SectTxt[sect]);
             writeline(pr, pr->Msg);
             writeline(pr, line);
             errsum++;

--- a/src/project.c
+++ b/src/project.c
@@ -816,13 +816,14 @@ int unlinked(Project *pr)
 {
     Network *net = &pr->network;
     int i, count = 0;
+	char errmsg[MAXMSG + 1] = "";
     
     for (i = 1; i <= net->Njuncs; i++)
     {
         if (pr->network.Adjlist[i] == NULL)
         {
             count++;
-            sprintf(pr->Msg, "Error 233: %s %s", geterrmsg(233, pr->Msg), net->Node[i].ID);
+            sprintf(pr->Msg, "Error 2331: %s %s", geterrmsg(2331, errmsg), net->Node[i].ID);
             writeline(pr, pr->Msg);
         }
         if (count >= 10) break;

--- a/src/project.c
+++ b/src/project.c
@@ -823,7 +823,7 @@ int unlinked(Project *pr)
         if (pr->network.Adjlist[i] == NULL)
         {
             count++;
-            sprintf(pr->Msg, "Error 2331: %s %s", geterrmsg(2331, errmsg), net->Node[i].ID);
+            sprintf(pr->Msg, "Error 234: %s %s", geterrmsg(234, errmsg), net->Node[i].ID);
             writeline(pr, pr->Msg);
         }
         if (count >= 10) break;


### PR DESCRIPTION
This fix solves the unconnected nodes garbled error message (Issue #608 ) and optionally adds an improved specific error message (number 2331) similar to the text in EPANET 2.1 when a network has unconnected nodes.

Another similar case in the code was found and corrected with the same pattern, but could not be tested.