### PR TITLE
Add EN_STARTTIME to EN_settimeparam function

### DIFF
--- a/ReleaseNotes2_3.md
+++ b/ReleaseNotes2_3.md
@@ -8,4 +8,6 @@ This document describes the changes and updates that have been made in version 2
  - A `EN_setvertex` function was added to allow API clients to change the coordinates of a single link vertex.
  - The index of a General Purpose Valve's (GPV's) head loss curve was added to the list of editable Link Properties using the symbolic constant name `EN_GPV_CURVE`.
  - The `EN_getlinkvalue` and `EN_setlinkvalue` functions were updated to get and set the value of `EN_GPV_CURVE`.
+ - Negative pressure values for `EN_SETTING` are now permitted in the `EN_setlinkvalue` function. 
+ - The `EN_STARTTIME` parameter was added into the `EN_settimeparam` function.
 

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/01/2020
+ Last Updated: 11/08/2020
  ******************************************************************************
 */
 
@@ -1583,6 +1583,11 @@ int DLLEXPORT EN_settimeparam(EN_Project p, int param, long value)
         rpt->Tstatflag = (char)value;
         break;
 
+    case EN_STARTTIME:
+        if (value > 86400) return 213;
+        time->Tstart = value;
+        break;
+ 
     case EN_HTIME:
         time->Htime = value;
         break;

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1583,11 +1583,6 @@ int DLLEXPORT EN_settimeparam(EN_Project p, int param, long value)
         rpt->Tstatflag = (char)value;
         break;
 
-    case EN_STARTTIME:
-        if (value > 86400) return 213;
-        time->Tstart = value;
-        break;
- 
     case EN_HTIME:
         time->Htime = value;
         break;
@@ -1597,7 +1592,7 @@ int DLLEXPORT EN_settimeparam(EN_Project p, int param, long value)
         break;
 
     case EN_STARTTIME:
-        if (value < 0 || value > SECperDAY) return 213;
+        if (value > SECperDAY) return 213;
 	    time->Tstart = value;
         break;
 


### PR DESCRIPTION
Allows setting the time of day when a simulation begins.