### PR TITLE
Update hydraul.c

### DIFF
--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -895,7 +895,7 @@ void  addenergy(Project *pr, long hstep)
         // Skip closed pumps
         pump = &net->Pump[j];
         k = pump->Link;
-        if (hyd->LinkStatus[k] <= CLOSED) continue;
+        if (pump->Energy.CurrentEffic == 0.0) continue;
         q = MAX(QZERO, ABS(hyd->LinkFlow[k]));
 
         // Find pump-specific energy cost


### PR DESCRIPTION
Fixes a bug that was adding time on-line to a closed pump's energy usage for the time step just prior to when a rule-based control re-opens it.