### PR TITLE
Fix pressure breaking valve: valve will generate head instead losing, when the flow is negative

### DIFF
--- a/src/hydcoeffs.c
+++ b/src/hydcoeffs.c
@@ -903,7 +903,7 @@ void  pbvcoeff(Project *pr, int k)
         else
         {
             hyd->P[k] = CBIG;
-            hyd->Y[k] = hyd->LinkSetting[k] * CBIG;
+            hyd->Y[k] = SGN(hyd->LinkFlow[k]) * hyd->LinkSetting[k] * CBIG;
         }
     }
 }


### PR DESCRIPTION
Currently, negative flow through a pressure breaking valve will cause the valve to _generate head_ instead of losing it. It is much more sensible for the PBV to always cause head losses, regardless of the flow direction through it. This way the PBVs can be safely added into the network, even when the flow directions are not known beforehand.