### PR TITLE
Fix getting current tanklevel with EN_getnodevalue()

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -2149,7 +2149,7 @@ int DLLEXPORT EN_getnodevalue(EN_Project p, int index, int property, double *val
 
     case EN_TANKLEVEL:
         if (index <= nJuncs) return 0;
-        v = (Tank[index - nJuncs].H0 - Node[index].El) * Ucf[ELEV];
+        v = (NodeHead[index] - Node[index].El) * Ucf[ELEV];
         break;
 
     case EN_INITVOLUME:


### PR DESCRIPTION
The documentation says that EN_getnodevalue(..., EN_TANKLEVEL, ...)
returns the current tank level, but the code instead returned the
initial level.  This change makes the code correspond to the
documentation.