### PR TITLE
Bugfix for En_getaveragepatternvalue() and Return MISSING initial setting from EN_getlinkvalue()

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4525,7 +4525,7 @@ int DLLEXPORT EN_getaveragepatternvalue(EN_Project p, int index, double *value)
 
     *value = 0.0;
     if (!p->Openflag) return 102;
-    if (index < 1 || index > net->Npats) return 205;
+    if (index < 0 || index > net->Npats) return 205;
     for (i = 0; i < Pattern[index].Length; i++)
     {
         *value += (double)Pattern[index].F[i];

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -3635,8 +3635,7 @@ int DLLEXPORT EN_getlinkvalue(EN_Project p, int index, int property, double *val
         {
             return EN_getlinkvalue(p, index, EN_ROUGHNESS, value);
         }
-		if (Link[index].Kc == MISSING) v = 0.0;
-        else v = Link[index].Kc;
+        v = Link[index].Kc;
         switch (Link[index].Type)
         {
         case PRV:
@@ -3648,6 +3647,9 @@ int DLLEXPORT EN_getlinkvalue(EN_Project p, int index, int property, double *val
             v *= Ucf[FLOW];
         default:
             break;
+        }
+        if (Link[index].Kc == MISSING) {
+          v = MISSING;
         }
         break;
 


### PR DESCRIPTION
Fixes a bug where 0 was not considered to be a valid pattern index.