### PR TITLE
Fixes possible integer overflow

### DIFF
--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/03/2020
+ Last Updated: 03/19/2022
  ******************************************************************************
 */
 
@@ -668,7 +668,7 @@ int  tanktimestep(Project *pr, long *tstep)
     Hydraul *hyd = &pr->hydraul;
 
     int     i, n, tankIdx = 0;
-    double  h, q, v;
+    double  h, q, v, xt;
     long    t;
     Stank   *tank;
 
@@ -691,7 +691,9 @@ int  tanktimestep(Project *pr, long *tstep)
         else continue;
 
         // Find time to fill/drain tank
-        t = (long)ROUND(v / q);
+        xt = v / q;
+        if (ABS(xt) > *tstep + 1) continue;
+        t = (long)ROUND(xt);
         if (t > 0 && t < *tstep)
         {
             *tstep = t;

--- a/src/input3.c
+++ b/src/input3.c
@@ -7,7 +7,7 @@ Description:  parses network data from a line of an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 11/29/2019
+Last Updated: 03/19/2022
 ******************************************************************************
 */
 
@@ -2159,6 +2159,7 @@ void changestatus(Network *net, int j, StatusType status, double y)
             if (y == 0.0) status = CLOSED;
         }
         else if (status == OPEN) link->Kc = 1.0;
+        else if (status == CLOSED) link->Kc = 0.0;
         link->Status = status;
     }
     else if (link->Type >= PRV)

--- a/src/input3.c
+++ b/src/input3.c
@@ -7,7 +7,7 @@ Description:  parses network data from a line of an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 03/19/2022
+Last Updated: 03/20/2022
 ******************************************************************************
 */
 


### PR DESCRIPTION
Fixes a possible integer overflow when computing time for a tank to fill/empty (issue #666 ). Also fixes issue #642 that failed to set a pump's initial setting to 0 when its initial status was CLOSED.