### PR TITLE
Bug in example code for detecting error conditions

### DIFF
--- a/doc/toolkit-usage.dox
+++ b/doc/toolkit-usage.dox
@@ -34,7 +34,7 @@ void runHydraulics(EN_Project ph, char *inputFile, char *reportFile)
     ERRCODE(EN_solveH(ph));
     ERRCODE(EN_saveH(ph));
     ERRCODE(EN_report(ph));
-    EN_geterror(ph, errcode, errmsg);
+    EN_geterror(errcode, errmsg, EN_MAXMSG);
     if (errcode) printf("\n%s\n", errmsg);
 }
 \endcode


### PR DESCRIPTION
EN_geterror doesn't take in the project wrapper, and you need to include maxLen.

Stumbled on this when I was copying the example from: http://wateranalytics.org/EPANET/toolkit-usage.html