### PR TITLE
Fix for GPV controls in EN_saveinpfile

### DIFF
--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -425,7 +425,7 @@ int saveinpfile(Project *pr, const char *fname)
         link = &net->Link[j];
 
         // Get text of control's link status/setting
-        if (control->Setting == MISSING)
+        if (control->Setting == MISSING || link->Type == GPV)
         {
             sprintf(s, " LINK %s %s ", link->ID, StatTxt[control->Status]);
         }


### PR DESCRIPTION
EN_saveinpfile was incorrectly saving the index of the GPV head loss curve inside of a simple control instead of the control status

This is a fix for #671 