### PR TITLE
fixes issue where a string position causes underflow

### DIFF
--- a/src/input2.c
+++ b/src/input2.c
@@ -630,7 +630,7 @@ int  gettokens(char *s, char** Tok, int maxToks, char *comment)
  */
 {
     int  n;
-    size_t len, m;
+    int len, m;
     char *c, *c2;
 
     // clear comment
@@ -648,10 +648,10 @@ int  gettokens(char *s, char** Tok, int maxToks, char *comment)
         if (c2)
         {
             // there is a comment here, after the semi-colon.
-            len = strlen(c2);
+            len = (int)strlen(c2);
             if (len > 0)
             {
-                len = strcspn(c2, "\n\r");
+                len = (int)strcspn(c2, "\n\r");
                 len = MIN(len, MAXMSG);
                 strncpy(comment, c2, len);
                 comment[MIN(len,MAXMSG)] = '\0';


### PR DESCRIPTION
under some circumstances, like certain input lines that have long comments, the code here can cause an underflow in size_t which casts to a very large integer during comparison and results in the number of tokens being over-reported (max of 40). Most of these tokens are of course garbage. Changing this `len` variable to an integer permits it to be less than zero, thus allowing an exit from the `while` at L665.