### PR TITLE
Fix error attribute index for output reader

### DIFF
--- a/src/outfile/src/epanet_output.c
+++ b/src/outfile/src/epanet_output.c
@@ -744,7 +744,7 @@ int EXPORT_OUT_API ENR_getNodeResult(ENR_Handle p_handle, int periodIndex,
     else
     {
         for (j = 0; j < NNODERESULTS; j++)
-            temp[j] = getNodeValue(p_handle, periodIndex, nodeIndex, j);
+            temp[j] = getNodeValue(p_handle, periodIndex, nodeIndex, j + 1);
 
         *outValueArray = temp;
         *length = NNODERESULTS;
@@ -772,7 +772,7 @@ int EXPORT_OUT_API ENR_getLinkResult(ENR_Handle p_handle, int periodIndex,
     else
     {
         for (j = 0; j < NLINKRESULTS; j++)
-            temp[j] = getLinkValue(p_handle, periodIndex, linkIndex, j);
+            temp[j] = getLinkValue(p_handle, periodIndex, linkIndex, j + 1);
 
         *outValueArray = temp;
         *length = NLINKRESULTS;


### PR DESCRIPTION
The attribute index starts from 1 rather than 0.
```cpp
typedef enum {
    ENR_demand      = 1,
    ENR_head        = 2,
    ENR_pressure    = 3,
    ENR_quality     = 4
} ENR_NodeAttribute;

typedef enum {
    ENR_flow        = 1,
    ENR_velocity    = 2,
    ENR_headloss    = 3,
    ENR_avgQuality  = 4,
    ENR_status      = 5,
    ENR_setting     = 6,
    ENR_rxRate      = 7,
    ENR_frctnFctr   = 8
} ENR_LinkAttribute;
```