### PR TITLE
Fixes incorrect hour set with >9 input tokens for simple controls

### DIFF
--- a/src/input3.c
+++ b/src/input3.c
@@ -922,7 +922,7 @@ int controldata(Project *pr)
         case TIMER:
         case TIMEOFDAY:
           if (n == 6) time = hour(parser->Tok[5], "");
-          if (n == 7) time = hour(parser->Tok[5], parser->Tok[6]);
+          if (n >= 7) time = hour(parser->Tok[5], parser->Tok[6]);
           if (time < 0.0) return setError(parser, 5, 213);
           break;
         case LOWLEVEL:


### PR DESCRIPTION
If you create a simple control with nine or more input tokens, the logic skips over assigning the hour variable and EPANET will activate the control at hour zero.

Fixes #709