### PR TITLE
Add support for cubic meters per second (CMS)

### DIFF
--- a/doc/input-file.dox
+++ b/doc/input-file.dox
@@ -278,7 +278,7 @@ Defines various simulation options.
 __Formats:__
 <table style = "border: 0px solid black">
 <tr><td><B>UNITS</B></td><td><B>CFS / GPM / MGD / IMGD / AFD /</B></td></tr>
-<tr><td>  </td><td><B>LPS / LPM / MLD / CMH / CMD</B></td></tr>
+<tr><td>  </td><td><B>LPS / LPM / MLD / CMS / CMH / CMD</B></td></tr>
 <tr><td><B>HEADLOSS</B></td><td><B>H-W / D-W / C-M</B></td></tr>
 <tr><td><B>HYDRAULICS</B></td><td><B>USE / SAVE </B><I>&nbsp;filename</I></td></tr>
 <tr><td><B>VISCOSITY</B></td><td><I>value</I></td></tr>
@@ -315,6 +315,7 @@ __Definitions:__
 - \b LPS = liters per second
 - \b LPM = liters per minute
 - \b MLD = million liters per day
+- \b CMS = cubic meters per second
 - \b CMH = cubic meters per hour
 - \b CMD = cubic meters per day
 

--- a/doc/toolkit-units.dox
+++ b/doc/toolkit-units.dox
@@ -17,8 +17,9 @@ The toolkit can use data expressed in either US Customary of SI Metric units. A 
 |Flow            | CFS (cubic feet / sec)  | LPS (liters / sec)        |
 |                | GPM (gallons / min)     | LPM (liters / min)        |
 |                | MGD (million gal / day) | MLD (megaliters / day)    |
-|                | IMGD (Imperial MGD)     | CMH (cubic meters / hr)   |
-|                | AFD (acre-feet / day)   | CMD (cubic meters / day)  |
+|                | IMGD (Imperial MGD)     | CMS (cubic meters / sec)  |
+|                | AFD (acre-feet / day)   | CMH (cubic meters / hr)   |
+|                |                         | CMD (cubic meters / day)  |
 |Friction Factor | unitless                | unitless                  |
 |Head            | feet                    | meters                    |
 |Length          | feet                    | meters                    |

--- a/include/epanet.cs
+++ b/include/epanet.cs
@@ -155,6 +155,7 @@ namespace EpanetCSharpLibrary
         public const int EN_MLD = 7;
         public const int EN_CMH = 8;
         public const int EN_CMD = 9;
+        public const int EN_CMS = 10;
 
         public const int EN_DDA = 0;           //Demand driven analysis
         public const int EN_PDA = 1;           //Pressure driven analysis

--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -152,6 +152,7 @@ Public Const EN_LPM = 6
 Public Const EN_MLD = 7
 Public Const EN_CMH = 8
 Public Const EN_CMD = 9
+Public Const EN_CMS = 10
 
 Public Const EN_DDA = 0           ' Demand driven analysis
 Public Const EN_PDA = 1           ' Pressure driven analysis

--- a/include/epanet2.pas
+++ b/include/epanet2.pas
@@ -158,6 +158,7 @@ const
  EN_MLD        = 7;
  EN_CMH        = 8;
  EN_CMD        = 9;
+ EN_CMS        = 10;
 
  EN_DDA        = 0;   { Demand model types }
  EN_PDA        = 1;  

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -147,6 +147,7 @@ Public Const EN_LPM = 6
 Public Const EN_MLD = 7
 Public Const EN_CMH = 8
 Public Const EN_CMD = 9
+Public Const EN_CMS = 10
 
 Public Const EN_DDA = 0           ' Demand driven analysis
 Public Const EN_PDA = 1           ' Pressure driven analysis

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -287,7 +287,8 @@ typedef enum {
   EN_LPM         = 6,   //!< Liters per minute
   EN_MLD         = 7,   //!< Million liters per day
   EN_CMH         = 8,   //!< Cubic meters per hour
-  EN_CMD         = 9    //!< Cubic meters per day
+  EN_CMD         = 9,   //!< Cubic meters per day
+  EN_CMS         = 10   //!< Cubic meters per second
 } EN_FlowUnits;
 
 /// Demand models

--- a/src/enumstxt.h
+++ b/src/enumstxt.h
@@ -59,7 +59,8 @@ char *RptFlowUnitsTxt[] = {u_CFS,
                            u_LPM,
                            u_MLD,
                            u_CMH,
-                           u_CMD};
+                           u_CMD,
+                           u_CMS};
 
 char *FlowUnitsTxt[]    = {w_CFS,
                            w_GPM, 
@@ -70,7 +71,8 @@ char *FlowUnitsTxt[]    = {w_CFS,
                            w_LPM, 
                            w_MLD, 
                            w_CMH,
-                           w_CMD};
+                           w_CMD,
+                           w_CMS};
 
 char *PressUnitsTxt[]   = {w_PSI,
                            w_KPA,

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -143,7 +143,7 @@ int DLLEXPORT EN_init(EN_Project p, const char *rptFile, const char *outFile,
     p->report.Rptflag = 1;
 
     // Check for valid arguments
-    if (unitsType < 0 || unitsType > CMD) return 251;
+    if (unitsType < 0 || unitsType > CMS) return 251;
     if (headLossType < 0 || headLossType > CM) return 251;
 
     // Open files
@@ -1427,6 +1427,7 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
     case MLD:
     case CMH:
     case CMD:
+    case CMS:
         p->parser.Unitsflag = SI;
         break;
     default:

--- a/src/input1.c
+++ b/src/input1.c
@@ -254,6 +254,7 @@ void adjustdata(Project *pr)
       case MLD: // megaliters/day
       case CMH: // cubic meters/hr
       case CMD: // cubic meters/day
+      case CMS: // cubic meters/second
         parser->Unitsflag = SI;
         break;
       default:
@@ -436,6 +437,7 @@ void initunits(Project *pr)
         if (parser->Flowflag == MLD) qcf = MLDperCFS;
         if (parser->Flowflag == CMH) qcf = CMHperCFS;
         if (parser->Flowflag == CMD) qcf = CMDperCFS;
+        if (parser->Flowflag == CMS) qcf = CMSperCFS;
 
         hcf = MperFT;
         if (parser->Pressflag == METERS) pcf = MperFT * hyd->SpGrav;

--- a/src/input3.c
+++ b/src/input3.c
@@ -1750,7 +1750,7 @@ int optionchoice(Project *pr, int n)
 **           those listed below, or -1 otherwise
 **  Purpose: processes fixed choice [OPTIONS] data
 **  Formats:
-**    UNITS               CFS/GPM/MGD/IMGD/AFD/LPS/LPM/MLD/CMH/CMD/SI
+**    UNITS               CFS/GPM/MGD/IMGD/AFD/LPS/LPM/MLD/CMH/CMD/CMS/SI
 **    PRESSURE            PSI/KPA/M
 **    HEADLOSS            H-W/D-W/C-M
 **    HYDRAULICS          USE/SAVE  filename
@@ -1790,6 +1790,7 @@ int optionchoice(Project *pr, int n)
         else if (match(parser->Tok[1], w_CMH))  parser->Flowflag = CMH;
         else if (match(parser->Tok[1], w_CMD))  parser->Flowflag = CMD;
         else if (match(parser->Tok[1], w_MLD))  parser->Flowflag = MLD;
+        else if (match(parser->Tok[1], w_CMS))  parser->Flowflag = CMS;
         else if (match(parser->Tok[1], w_SI))   parser->Flowflag = LPS;
         else return setError(parser, 1, 213);
     }

--- a/src/outfile/include/epanet_output_enums.h
+++ b/src/outfile/include/epanet_output_enums.h
@@ -33,7 +33,8 @@ typedef enum {
     ENR_LPM         = 6,
     ENR_MLD         = 7,
     ENR_CMH         = 8,
-    ENR_CMD         = 9
+    ENR_CMD         = 9,
+    ENR_CMS         = 10
 } ENR_FlowUnits;
 
 typedef enum {

--- a/src/outfile/src/epanet_output.c
+++ b/src/outfile/src/epanet_output.c
@@ -295,6 +295,7 @@ int EXPORT_OUT_API ENR_getUnits(ENR_Handle p_handle, ENR_Units code, int* unitFl
  **  7 = megaliters/day
  **  8 = cubic meters/hour
  **  9 = cubic meters/day
+ **  10 = cubic meters/sec
  **-------------------------------------------------------------------------
  */
 {

--- a/src/text.h
+++ b/src/text.h
@@ -87,6 +87,7 @@
 #define   w_MLD         "MLD"
 #define   w_CMH         "CMH"
 #define   w_CMD         "CMD"
+#define   w_CMS         "CMS"
 #define   w_SI          "SI"
 
 #define   w_PSI         "PSI"
@@ -236,6 +237,7 @@
 #define   u_IMGD        "Imgd"
 #define   u_LPS         "L/s"
 #define   u_LPM         "Lpm"
+#define   u_CMS         "m3/s"
 #define   u_CMH         "m3/h"
 #define   u_CMD         "m3/d"
 #define   u_MLD         "ML/d"

--- a/src/types.h
+++ b/src/types.h
@@ -71,6 +71,7 @@ typedef  int          INT4;
 #define   IMGDperCFS  0.5382
 #define   LPSperCFS   28.317
 #define   LPMperCFS   1699.0
+#define   CMSperCFS   0.028317
 #define   CMHperCFS   101.94
 #define   CMDperCFS   2446.6
 #define   MLDperCFS   2.4466
@@ -227,7 +228,8 @@ typedef enum {
   LPM,           // liters per minute
   MLD,           // megaliters per day
   CMH,           // cubic meters per hour
-  CMD            // cubic meters per day
+  CMD,           // cubic meters per day
+  CMS            // cubic meters per second
 } FlowUnitsType;
 
 typedef enum {

--- a/tests/test_demand.cpp
+++ b/tests/test_demand.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(test_cms_unit)
     error = EN_close(ph);
     BOOST_REQUIRE(error == 0);
 
-    int error = EN_init(ph, DATA_PATH_RPT, DATA_PATH_OUT, EN_CMS+1, EN_HW);
+    error = EN_init(ph, DATA_PATH_RPT, DATA_PATH_OUT, EN_CMS+1, EN_HW);
     BOOST_REQUIRE(error == 251);
 
     EN_deleteproject(ph);

--- a/tests/test_demand.cpp
+++ b/tests/test_demand.cpp
@@ -122,5 +122,31 @@ BOOST_FIXTURE_TEST_CASE(test_adddemand, FixtureSingleNode)
     BOOST_CHECK(nD1 - nD2 == 1);
 }
 
+BOOST_AUTO_TEST_CASE(test_cms_unit)
+{
+    int flowType;
+
+    EN_Project ph = NULL;
+    EN_createproject(&ph);
+
+    int error = EN_init(ph, DATA_PATH_RPT, DATA_PATH_OUT, EN_CMS, EN_HW);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_setflowunits(ph, EN_CMS);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getflowunits(ph, &flowType );
+    BOOST_REQUIRE(error == 0);
+    BOOST_REQUIRE(flowType == EN_CMS);
+
+    error = EN_close(ph);
+    BOOST_REQUIRE(error == 0);
+
+    int error = EN_init(ph, DATA_PATH_RPT, DATA_PATH_OUT, EN_CMS+1, EN_HW);
+    BOOST_REQUIRE(error == 251);
+
+    EN_deleteproject(ph);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I've added support for cubic meters per second, the tests are very basic and cover the most simple cases.

I haven't modified anything under `src/outfile` but can push another commit if we want to update and there is support for adding CMS flow units into EPANET.

Fixes #712