### PR TITLE
setlinkvalue missing a break

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4134,6 +4134,7 @@ int DLLEXPORT EN_setlinkvalue(EN_Project p, int index, int property, double valu
             if (curveIndex < 0 || curveIndex > net->Ncurves) return 206;
             Link[index].Kc = curveIndex;
         }
+        break;
 
     default:
         return 251;


### PR DESCRIPTION
simple omission bug preventing use of setlinkvalue for EN_GPV_CURVE case.
