### PR TITLE
setlinkvalue missing a break statement

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4134,6 +4134,7 @@ int DLLEXPORT EN_setlinkvalue(EN_Project p, int index, int property, double valu
             if (curveIndex < 0 || curveIndex > net->Ncurves) return 206;
             Link[index].Kc = curveIndex;
         }
+        break;
 
     default:
         return 251;

--- a/src/project.c
+++ b/src/project.c
@@ -1074,7 +1074,7 @@ int adjustpumpparams(Project *pr, int curveIndex)
         {
             // Update its head curve parameters
             pump->Ptype = NOCURVE;
-            err = updatepumpparams(pr, curveIndex);
+            err = updatepumpparams(pr, j);
             if (err > 0) break;
             
             // Convert parameters to internal units


### PR DESCRIPTION
simple omission bug preventing use of setlinkvalue for EN_GPV_CURVE when the link is not a GPV.