### PR TITLE
Bugfix

### DIFF
--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 08/13/2022
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -718,7 +718,7 @@ int  controltimestep(Project *pr, long *tstep)
     Network *net = &pr->network;
     Hydraul *hyd = &pr->hydraul;
 
-    int    i, j, k, n, controlIndex;
+    int    i, j, k, n, controlIndex = 0;
     double h, q, v;
     long   t, t1, t2;
     Slink  *link;

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 05/15/2019
+ Last Updated: 08/02/2023
 
  This module is based code by Steve Hill in Graphics Gems III,
  David Kirk (ed.), Academic Press, Boston, MA, 1992
@@ -72,7 +72,11 @@ struct Mempool * mempool_create()
     if (mempool == NULL) return NULL;
     mempool->first = createMemBlock();
     mempool->current = mempool->first;
-    if (mempool->first == NULL) return NULL;
+    if (mempool->first == NULL)
+    {
+        free(mempool);
+        return NULL;
+    }
     return mempool;
 }
 

--- a/src/outfile/src/epanet_output.c
+++ b/src/outfile/src/epanet_output.c
@@ -3,7 +3,8 @@
 //   epanet_output.c -- API for reading results from EPANET binary output file
 //
 //   Version:    0.40
-//   Date        04/02/2019
+//   Date        08/02/2023
+//               04/02/2019
 //               09/06/2017
 //               06/17/2016
 //               08/05/2014
@@ -252,12 +253,15 @@ int EXPORT_OUT_API ENR_getNetSize(ENR_Handle p_handle, int** elementCount, int* 
  */
 {
     int errorcode = 0;
-    int* temp = newIntArray(NELEMENTTYPES);
+    int* temp;
     data_t* p_data;
 
     p_data = (data_t*)p_handle;
 
     if (p_data == NULL) return -1;
+    // Check memory for count values
+    else if MEMCHECK(temp = newIntArray(NELEMENTTYPES)) errorcode = 411;
+    
     else
     {
         temp[0] = p_data->nodeCount;
@@ -459,6 +463,7 @@ int EXPORT_OUT_API ENR_getElementName(ENR_Handle p_handle, ENR_ElementType type,
             *name = temp;
             *length = MAXID_P1;
         }
+        else free(temp);
     }
 
     return set_error(p_data->error_handle, errorcode);

--- a/src/project.c
+++ b/src/project.c
@@ -560,31 +560,41 @@ int  addlinkvertex(Slink *link, double x, double y)
 */
 {
     static int CHUNKSIZE = 5;
-    int n;
+    int n, newCapacity;
     Pvertices vertices;
-    if (link->Vertices == NULL)
+    double *newX, *newY;
+
+    vertices = link->Vertices;
+    if (vertices == NULL)
     {
         vertices = (struct Svertices *) malloc(sizeof(struct Svertices));
         if (vertices == NULL) return 101;
         vertices->Npts = 0;
-        vertices->Capacity = CHUNKSIZE;
-        vertices->X = (double *) calloc(vertices->Capacity, sizeof(double));
-        vertices->Y = (double *) calloc(vertices->Capacity, sizeof(double));
+        vertices->Capacity = 0;
+        vertices->X = NULL;
+        vertices->Y = NULL;
         link->Vertices = vertices;
     }
-    vertices = link->Vertices;
     if (vertices->Npts >= vertices->Capacity)
     {
-        vertices->Capacity += CHUNKSIZE;
-        vertices->X = realloc(vertices->X, vertices->Capacity * sizeof(double));
-        vertices->Y = realloc(vertices->Y, vertices->Capacity * sizeof(double));
+        newCapacity = vertices->Capacity + CHUNKSIZE;
+        newX = realloc(vertices->X, newCapacity * sizeof(double));
+        newY = realloc(vertices->Y, newCapacity * sizeof(double));
+        if (newX == NULL || newY == NULL)
+        {
+            free(newX);
+            free(newY);
+            return 101;
+        }
+        vertices->Capacity = newCapacity;
+        vertices->X = newX;
+        vertices->Y = newY;
     }
-    if (vertices->X == NULL || vertices->Y == NULL) return 101;
     n = vertices->Npts;
     vertices->X[n] = x;
     vertices->Y[n] = y;
     vertices->Npts++;
-    return 0;    
+    return 0;
 }
 
 void freelinkvertices(Slink *link)

--- a/src/project.c
+++ b/src/project.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/29/2023
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -1373,10 +1373,10 @@ char *xstrcpy(char **s1, const char *s2, const size_t n)
 //           s1 points to a valid memory location or is NULL. E.g.,
 //           the following code will likely cause a segment fault:
 //             char *s;
-//             s = xstrcpy(s, "Some text");
+//             s = xstrcpy(&s, "Some text");
 //           while this would work correctly:
 //             char *s = NULL;
-//             s = xstrcpy(s, "Some text");
+//             s = xstrcpy(&s, "Some text");
 //----------------------------------------------------------------
 {
     size_t n1 = 0, n2 = 0;
@@ -1398,7 +1398,7 @@ char *xstrcpy(char **s1, const char *s2, const size_t n)
     if (n2 > n1) *s1 = realloc(*s1, (n2 + 1) * sizeof(char));
 
     // Copy the source string into the destination string
-    strncpy(*s1, s2, n2+1);
+    if (*s1) strncpy(*s1, s2, n2+1);
     return *s1;
 }
 

--- a/src/qualroute.c
+++ b/src/qualroute.c
@@ -7,7 +7,7 @@ Description:  computes water quality transport over a single time step
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 05/15/2019
+Last Updated: 08/02/2023
 ******************************************************************************
 */
 
@@ -609,7 +609,7 @@ void initsegs(Project *pr)
         addseg(pr, k, v, c);
 
         // Create a 2nd segment for the 2-compartment tank model
-        if (net->Tank[j].MixModel == MIX2)
+        if (!qual->OutOfMemory && net->Tank[j].MixModel == MIX2)
         {
             // ... mixing zone segment
             v1 = MAX(0, v - net->Tank[j].V1frac * net->Tank[j].Vmax);

--- a/src/util/errormanager.c
+++ b/src/util/errormanager.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/02/2019
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -36,6 +36,7 @@ error_handle_t *create_error_manager(void (*p_error_message)(int, char*, int))
 {
 	error_handle_t *error_handle;
 	error_handle = (error_handle_t*)calloc(1, sizeof(error_handle_t));
+	if (error_handle == NULL) return NULL;
 
 	error_handle->p_msg_lookup = p_error_message;
 

--- a/src/util/filemanager.c
+++ b/src/util/filemanager.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/01/2019
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -41,6 +41,7 @@ file_handle_t *create_file_manager() {
 
     file_handle_t *file_handle;
     file_handle = (file_handle_t *)calloc(1, sizeof(file_handle_t));
+    if (file_handle == NULL) return NULL;
 
 	file_handle->filename = NULL;
 	file_handle->file = NULL;

--- a/tests/test_demand.cpp
+++ b/tests/test_demand.cpp
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 03/21/2019
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -27,7 +27,9 @@ BOOST_AUTO_TEST_CASE(test_categories_save)
     EN_Project ph = NULL;
 
     error = EN_createproject(&ph);
+    BOOST_REQUIRE(error == 0);
     error = EN_open(ph, DATA_PATH_NET1, DATA_PATH_RPT, DATA_PATH_OUT);
+    BOOST_REQUIRE(error == 0);
 
     error = EN_getnodeindex(ph, (char *)"12", &Nindex);
     BOOST_REQUIRE(error == 0);

--- a/tests/test_overflow.cpp
+++ b/tests/test_overflow.cpp
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 06/16/2019
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -32,7 +32,9 @@ BOOST_AUTO_TEST_CASE(test_tank_overflow)
     EN_Project ph = NULL;
 
     error = EN_createproject(&ph);
+    BOOST_REQUIRE(error == 0);
     error = EN_open(ph, DATA_PATH_NET1, DATA_PATH_RPT, "");
+    BOOST_REQUIRE(error == 0);
 
     // Get index of the tank and its inlet/outlet pipe
     error = EN_getnodeindex(ph, (char *)"2", &Nindex);

--- a/tests/test_pda.cpp
+++ b/tests/test_pda.cpp
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 07/20/2019
+ Last Updated: 08/02/2023
  ******************************************************************************
 */
 
@@ -30,7 +30,9 @@ BOOST_AUTO_TEST_CASE(test_pda_model)
 
     EN_Project ph = NULL;
     error = EN_createproject(&ph);
+    BOOST_REQUIRE(error == 0);
     error = EN_open(ph, DATA_PATH_NET1, DATA_PATH_RPT, "");
+    BOOST_REQUIRE(error == 0);
 
     // Set Demand Multiplier to 10 to cause negative pressures
     error = EN_setoption(ph, EN_DEMANDMULT, 10);


### PR DESCRIPTION
We're going to use EPANET in some serious scenarios which requires passing the static analyzer.

We fixed all problems reported in gcc static analyzer `-fanalyzer`, and all but problems in "Unused code" category in Clang analyzer `scan-build`.