### PR TITLE
Fixes conan build, adds documentation for this option

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,6 +24,15 @@ These two scripts build EPANET binaries for both the 32 and 64 bit Windows platf
 
 A tutorial on [building OWA EPANET from source on Windows](tools/BuildAndTest.md), including running unit tests and performing regression testing, is also avaiable.
 
+## Alternative build with Conan
+Conan is an increasingly popular C/C++ package management suite. To build EPANET using Conan, use the following commands as a starting point:
+
+```
+conan build . -s build_type=Release
+conan export-pkg . -s build_type=Release
+```
+
+
 # Testing
 
 Unit tests have been written using the Boost Unit Testing Framework and other Boost libraries. The tests are compiled into individual executables that automatically perform checks on the EPANET toolkit and output libraries.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ target_include_directories(epanet2 PUBLIC ${PROJECT_SOURCE_DIR}/include)
 install(TARGETS epanet2 DESTINATION lib)
 install(FILES ./include/epanet2.h DESTINATION include)
 install(FILES ./include/epanet2_2.h DESTINATION include)
+install(FILES ./include/epanet2_enums.h DESTINATION include)
 install(DIRECTORY ./src/ DESTINATION include FILES_MATCHING PATTERN "*.h")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,10 @@ project(EPANET)
 # Append local dir to module search path
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(BUILD_TESTS "Build tests (requires Boost)" OFF)
 option(BUILD_PY_LIB "Build library for Python wrapper" OFF)
 option(BUILD_COVERAGE "Build library for coverage" OFF)
-
 
 IF (NOT BUILD_PY_LIB)
   add_subdirectory(run)
@@ -96,7 +96,14 @@ IF(MSVC AND "${CMAKE_VS_PLATFORM_NAME}" MATCHES "(Win32)")
   add_library(epanet2 SHARED ${EPANET_LIB_ALL} ${PROJECT_SOURCE_DIR}/include/epanet2.def)
   set_source_files_properties(${PROJECT_SOURCE_DIR}/include/epanet2.def PROPERTIES_HEADER_FILE_ONLY TRUE)
 ELSE(TRUE)
-  add_library(epanet2 SHARED ${EPANET_LIB_ALL})
+  add_library(epanet2 ${EPANET_LIB_ALL})
 ENDIF(MSVC AND "${CMAKE_VS_PLATFORM_NAME}" MATCHES "(Win32)")
 
 target_include_directories(epanet2 PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+install(TARGETS epanet2 DESTINATION lib)
+install(FILES ./include/epanet2.h DESTINATION include)
+install(FILES ./include/epanet2_2.h DESTINATION include)
+install(DIRECTORY ./src/ DESTINATION include FILES_MATCHING PATTERN "*.h")
+
+

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,5 +38,5 @@ class EpanetConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libdirs = ["lib"]
-        self.cpp_info.libs = ["epanet2", "epanet-output"]
+        self.cpp_info.libs = ["epanet2"]
         self.cpp_info.includedirs = ["include"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile
+from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class EpanetConan(ConanFile):
@@ -33,11 +33,8 @@ class EpanetConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy("lib/libepanet2.dylib", "lib", keep_path=False)
-        self.copy("lib/libepanet-output.dylib", "lib", keep_path=False)
-        self.copy("*.h", "include", "include", keep_path=False)
-        self.copy("types.h", "include", "src", keep_path=False)
-        self.copy("hash.h", "include", "src", keep_path=False)
+        cmake = CMake(self)
+        cmake.install()
 
     def package_info(self):
         self.cpp_info.libdirs = ["lib"]


### PR DESCRIPTION
additionally, this PR adds install target locations and an optional cmake def for building epanet as a static library - `-DBUILD_SHARED_LIBS=OFF` as these are common cmake conventions.