### PR TITLE
Changes EMITTER BACKFLOW keyword

### DIFF
--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -1,13 +1,13 @@
 /*
 ******************************************************************************
 Project:      OWA EPANET
-Version:      2.2
+Version:      2.3
 Module:       inpfile.c
 Description:  saves network data to an EPANET formatted text file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 04/30/2023
+Last Updated: 05/11/2024
 ******************************************************************************
 */
 
@@ -682,7 +682,7 @@ int saveinpfile(Project *pr, const char *fname)
         fprintf(f, "\n PATTERN             %s", net->Pattern[hyd->DefPat].ID);
     fprintf(f, "\n DEMAND MULTIPLIER   %-.4f", hyd->Dmult);
     fprintf(f, "\n EMITTER EXPONENT    %-.4f", 1.0 / hyd->Qexp);
-    fprintf(f, "\n EMITTER BACKFLOW    %s", BackflowTxt[hyd->EmitBackFlag]);
+    fprintf(f, "\n BACKFLOW ALLOWED    %s", BackflowTxt[hyd->EmitBackFlag]);
     fprintf(f, "\n VISCOSITY           %-.6f", hyd->Viscos / VISCOS);
     fprintf(f, "\n DIFFUSIVITY         %-.6f", qual->Diffus / DIFFUS);
     fprintf(f, "\n SPECIFIC GRAVITY    %-.6f", hyd->SpGrav);

--- a/src/input3.c
+++ b/src/input3.c
@@ -7,7 +7,7 @@ Description:  parses network data from a line of an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 09/28/2023
+Last Updated: 05/11/2024
 ******************************************************************************
 */
 
@@ -1832,7 +1832,7 @@ int optionchoice(Project *pr, int n)
 **    UNBALANCED          STOP/CONTINUE {Niter}
 **    PATTERN             id
 **    DEMAND MODEL        DDA/PDA
-**    EMITTER BACKFLOW    YES/NO
+**    BACKFLOW ALLOWED    YES/NO
 **--------------------------------------------------------------
 */
 {
@@ -1956,11 +1956,11 @@ int optionchoice(Project *pr, int n)
         hyd->DemandModel = choice;
     }
     
-    // EMITTER BACKFLOW
-    else if (match(parser->Tok[0], w_EMITTER))
+    // Emitter BACKFLOW ALLOWED
+    else if (match(parser->Tok[0], w_BACKFLOW))
     {
         if (n < 2) return 0;
-        if (!match(parser->Tok[1], w_BACKFLOW)) return -1;
+        if (!match(parser->Tok[1], w_ALLOWED)) return -1;
         choice = findmatch(parser->Tok[2], BackflowTxt);
         if (choice < 0) return setError(parser, 2, 213);
         hyd->EmitBackFlag = choice;

--- a/src/text.h
+++ b/src/text.h
@@ -1,13 +1,13 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       text.h
  Description:  string constants used throughout EPANET
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/05/2023
+ Last Updated: 05/11/2024
  ******************************************************************************
 */
 
@@ -130,6 +130,7 @@
 #define   w_TOLERANCE   "TOLER"
 #define   w_EMITTER     "EMIT"
 #define   w_BACKFLOW    "BACK"
+#define   w_ALLOWED     "ALLOW"
 
 #define   w_PRICE       "PRICE"
 #define   w_DMNDCHARGE  "DEMAN"


### PR DESCRIPTION
This change avoids a conflict between the EMITTER EXPONENT and EMITTER BACKFLOW keywords when running a v2.3 input file in the v2.2 EPANET GUI.