### PR TITLE
Fix Issue #789 - free network Adjlist

### DIFF
--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -286,6 +286,7 @@ void  closehyd(Project *pr)
 {
     freesparse(pr);
     freematrix(pr);
+    freeadjlists(pr);
 }
 
 

--- a/src/quality.c
+++ b/src/quality.c
@@ -410,6 +410,7 @@ int closequal(Project *pr)
         FREE(qual->FlowDir);
         FREE(qual->SortedNodes);
     }
+    freeadjlists(pr);
     return errcode;
 }
 


### PR DESCRIPTION
This is the proposed fix for Issue #789. 

It is the fastest and most straightforward solution I could think of. The only drawback is the freeing of Adjlist between hydraulics and quality simulations.

Alternatively, one could think of invalidating and freeing it whenever an element (node or a link) is added to the network.