### PR TITLE
Fix Issue 789- PR 791 

### DIFF
--- a/src/hydraul.c
+++ b/src/hydraul.c
@@ -286,7 +286,7 @@ void  closehyd(Project *pr)
 {
     freesparse(pr);
     freematrix(pr);
-    freeadjlists(pr);
+    freeadjlists(&pr->network);
 }
 
 

--- a/src/quality.c
+++ b/src/quality.c
@@ -410,7 +410,7 @@ int closequal(Project *pr)
         FREE(qual->FlowDir);
         FREE(qual->SortedNodes);
     }
-    freeadjlists(pr);
+    freeadjlists(&pr->network);
     return errcode;
 }
 


### PR DESCRIPTION
In the previous PR, I added the `freeadjlists(pr)` in the hydraulic and quality close function. However, the function needs a pointer to a network. 