### PR TITLE
Fix two legacy API functions

### DIFF
--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -357,7 +357,16 @@ int DLLEXPORT ENgetnodevalue(int index, int property, EN_API_FLOAT_TYPE *value)
 
 int DLLEXPORT ENgetnodevalues(int property, EN_API_FLOAT_TYPE *values)
 {
-    return EN_getnodevalues(_defaultProject, property, values);
+    int i, errcode = 0;
+    EN_API_FLOAT_TYPE value;
+    
+    for (i = 1; i <= _defaultProject->network.Nnodes; i++)
+    {
+        errcode = ENgetnodevalue(i, property, &value);
+        values[i-1] = value;
+        if (errcode != 0) return errcode;
+    }
+    return 0;
 }
 
 int DLLEXPORT ENsetnodevalue(int index, int property, EN_API_FLOAT_TYPE value)
@@ -530,7 +539,16 @@ int DLLEXPORT ENgetlinkvalue(int index, int property, EN_API_FLOAT_TYPE *value)
 }
 int DLLEXPORT ENgetlinkvalues(int property, EN_API_FLOAT_TYPE *values)
 {
-    return EN_getlinkvalues(_defaultProject, property, values);
+    int i, errcode = 0;
+    EN_API_FLOAT_TYPE value;
+    
+    for (i = 1; i <= _defaultProject->network.Nlinks; i++)
+    {
+        errcode = ENgetlinkvalue(i, property, &value);
+        values[i-1] = value;
+        if (errcode != 0) return errcode;
+    }
+    return 0;
 }
 
 int DLLEXPORT ENsetlinkvalue(int index, int property, EN_API_FLOAT_TYPE value)

--- a/src/report.c
+++ b/src/report.c
@@ -291,7 +291,7 @@ void writesummary(Project *pr)
   if (qual->Qualflag == NONE || time->Dur == 0.0) sprintf(s, FMT29);
   else if (qual->Qualflag == CHEM)  sprintf(s, FMT30, qual->ChemName);
   else if (qual->Qualflag == TRACE) sprintf(s, FMT31, net->Node[qual->TraceNode].ID);
-  else if (qual->Qualflag == AGE)   printf(s, FMT32);
+  else if (qual->Qualflag == AGE)   sprintf(s, FMT32);
   writeline(pr, s);
   if (qual->Qualflag != NONE && time->Dur > 0)
   {


### PR DESCRIPTION
Fixes problem with incompatible argument types in the legacy API functions `ENgetnodevalues `and `ENgetlinkvalues`.