### PR TITLE
fixes regression related to tank fill/empty events

### DIFF
--- a/src/hydstatus.c
+++ b/src/hydstatus.c
@@ -433,10 +433,10 @@ void  tankstatus(Project *pr, int k, int n, double q)
     if (tank->A == 0.0) return;
     
     // Can't add flow to a full tank
-    if (hyd->NodeHead[n] >= tank->Hmax && !tank->CanOverflow && q < TINY)
+    if (hyd->NodeHead[n] >= tank->Hmax && !tank->CanOverflow && q < 0.0)
         hyd->LinkStatus[k] = TEMPCLOSED;
  
     // Can't remove flow from an empty tank
-    else if (hyd->NodeHead[n] <= tank->Hmin && q > -TINY)
+    else if (hyd->NodeHead[n] <= tank->Hmin && q > 0.0)
         hyd->LinkStatus[k] = TEMPCLOSED;
 }


### PR DESCRIPTION
In the affected code, q is really just a proxy for flow direction. And in cases where a tank has filled in a previous step, its connected link will have been TEMPCLOSED making the flow a very small (positive or negative) number. When this occurs, the link actually never opens even if dH says that the tank should be draining.