### PR TITLE
Replace 2.2 with 2.3 in file headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,3 @@ The **Open Water Analytics** (OWA) Community is an international group of EPANET
 
 ## DISCLAIMER
 Although OWA is not formally affiliated with nor endorsed by USEPA, this project has been a collaborative effort between the two that builds upon and extends the USEPA’s legacy EPANET 2.0 code base. For the last "official" release of EPANET please go to the [USEPA website](http://www2.epa.gov/water-research/epanet).
-
-For more general community discussion, FAQ, and roadmapping of the project, please go to the [Community Forum](http://community.wateranalytics.org).

--- a/run/main.c
+++ b/run/main.c
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       main.c
  Description:  main stub for a command line executable version of EPANET
  Authors:      see AUTHORS

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,7 +1,7 @@
  /*
   ******************************************************************************
   Project:      OWA EPANET
-  Version:      2.2
+  Version:      2.3
   Module:       hash.c
   Description:  implementation of a simple hash table
   Authors:      see AUTHORS

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       hash.h
  Description:  header for a simple hash table
  Authors:      see AUTHORS

--- a/src/hydcoeffs.c
+++ b/src/hydcoeffs.c
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       hydcoeffs.c
  Description:  computes coefficients for a hydraulic solution matrix
  Authors:      see AUTHORS

--- a/src/hydsolver.c
+++ b/src/hydsolver.c
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       hydsolver.c
  Description:  computes flows and pressures throughout a pipe network using
                Todini's Global Gradient Algorithm

--- a/src/hydstatus.c
+++ b/src/hydstatus.c
@@ -1,7 +1,7 @@
 /*
 ******************************************************************************
 Project:      OWA EPANET
-Version:      2.2
+Version:      2.3
 Module:       hydstatus.c
 Description:  updates hydraulic status of network elements
 Authors:      see AUTHORS

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       mempool.c
  Description:  a simple fast poooled memory allocation package
  Authors:      see AUTHORS

--- a/src/mempool.h
+++ b/src/mempool.h
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       mempool.h
  Description:  header for a simple pooled memory allocator
  Authors:      see AUTHORS

--- a/src/output.c
+++ b/src/output.c
@@ -1,7 +1,7 @@
 /*
 ******************************************************************************
 Project:      OWA EPANET
-Version:      2.2
+Version:      2.3
 Module:       output.c
 Description:  binary file read/write routines
 Authors:      see AUTHORS

--- a/src/qualreact.c
+++ b/src/qualreact.c
@@ -1,7 +1,7 @@
 /*
 ******************************************************************************
 Project:      OWA EPANET
-Version:      2.2
+Version:      2.3
 Module:       qualreact.c
 Description:  computes water quality reactions within pipes and tanks
 Authors:      see AUTHORS

--- a/src/smatrix.c
+++ b/src/smatrix.c
@@ -1,7 +1,7 @@
 /*
  ******************************************************************************
  Project:      OWA EPANET
- Version:      2.2
+ Version:      2.3
  Module:       smatrix.c
  Description:  solves a sparse set of linear equations
  Authors:      see AUTHORS


### PR DESCRIPTION
Avoid confusion about to which version a source code file belongs.