### PR TITLE
Add option for rule operator precedence

### DIFF
--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -267,6 +267,9 @@ Public Const EN_R_NOT = 7
 Public Const EN_R_BELOW = 8
 Public Const EN_R_ABOVE = 9
 
+Public Const EN_R_PREC_LEGACY   = 0     ' Rule operator precedence
+Public Const EN_R_PREC_STANDARD = 1
+
 Public Const EN_R_IS_OPEN = 1     ' Rule status types
 Public Const EN_R_IS_CLOSED = 2
 Public Const EN_R_IS_ACTIVE = 3

--- a/include/epanet2.cs
+++ b/include/epanet2.cs
@@ -270,6 +270,9 @@ namespace EpanetCSharpLibrary
         public const int EN_R_BELOW = 8;
         public const int EN_R_ABOVE = 9;
 
+        public const int EN_R_PREC_LEGACY   = 0;    //Rule operator precedence
+        public const int EN_R_PREC_STANDARD = 1;
+
         public const int EN_R_IS_OPEN   = 1;   //Rule status types
         public const int EN_R_IS_CLOSED = 2;
         public const int EN_R_IS_ACTIVE = 3;

--- a/include/epanet2.pas
+++ b/include/epanet2.pas
@@ -273,7 +273,10 @@ const
  EN_R_IS        = 6;
  EN_R_NOT       = 7;
  EN_R_BELOW     = 8;
- EN_R_ABOVE     = 9; 
+ EN_R_ABOVE     = 9;
+
+ EN_R_PREC_LEGACY   = 0;   { Rule-based control operator precedence }
+ EN_R_PREC_STANDARD = 1;
  
  EN_R_IS_OPEN   = 1;   { Rule-based control link status }
  EN_R_IS_CLOSED = 2;

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -261,6 +261,9 @@ Public Const EN_R_NOT   = 7
 Public Const EN_R_BELOW = 8
 Public Const EN_R_ABOVE = 9
 
+Public Const EN_R_PREC_LEGACY   = 0;   ' Rule operator precedence
+Public Const EN_R_PREC_STANDARD = 1;
+
 Public Const EN_R_IS_OPEN   = 1   ' Rule status types
 Public Const EN_R_IS_CLOSED = 2
 Public Const EN_R_IS_ACTIVE = 3

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -359,7 +359,8 @@ typedef enum {
   EN_DEMANDPATTERN  = 23, //!< Name of default demand pattern
   EN_EMITBACKFLOW   = 24, //!< 1 if emitters can backflow, 0 if not
   EN_PRESS_UNITS    = 25, //!< Pressure units (see @ref EN_PressUnits)
-  EN_STATUS_REPORT  = 26  //!< Type of status report to produce (see @ref EN_StatusReport)
+  EN_STATUS_REPORT  = 26, //!< Type of status report to produce (see @ref EN_StatusReport)
+  EN_RULE_OP_PREC   = 27  //!< Precedence between AND/OR in rules
 } EN_Option;
 
 /// Simple control types
@@ -500,6 +501,12 @@ typedef enum {
   EN_R_BELOW     = 8,   //!< Is below
   EN_R_ABOVE     = 9    //!< Is above
 } EN_RuleOperator;
+
+/// Operator precedence used in rule-based controls
+typedef enum {
+  EN_R_PREC_LEGACY = 0,   //!< OR goes first, AND goes later
+  EN_R_PREC_STANDARD = 1  //!< AND goes first, OR goes later
+} EN_RuleOpPrec;
 
 /// Link status codes used in rule-based controls
 typedef enum {

--- a/src/enumstxt.h
+++ b/src/enumstxt.h
@@ -117,6 +117,10 @@ char *RptFlagTxt[]      = {w_NO,
 char *BackflowTxt[]     = {w_NO,
                            w_YES,
                            NULL};
+
+char *OpPrecTxt[]       = {w_LEGACY,
+                           w_STANDARD,
+                           NULL};
                            
 char *CurveTypeTxt[]    = {c_VOLUME,
                            c_PUMP,

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -139,6 +139,7 @@ int DLLEXPORT EN_init(EN_Project p, const char *rptFile, const char *outFile,
     p->outfile.SaveHflag = FALSE;
     p->outfile.SaveQflag = FALSE;
     p->Warnflag = FALSE;
+    p->OpPrec = LEGACY;
     p->report.Messageflag = TRUE;
     p->report.Rptflag = 1;
 
@@ -1433,6 +1434,12 @@ int DLLEXPORT EN_setoption(EN_Project p, int option, double value)
         i = ROUND(value);
         if (i < EN_NO_REPORT || i > EN_FULL_REPORT) return 213;
         p->report.Statflag = i;
+        break;
+
+    case EN_RULE_OP_PREC:
+        i = ROUND(value);
+        if (i < EN_R_PREC_LEGACY || i > EN_R_PREC_STANDARD) return 213;
+        p->OpPrec = i;
         break;
 
     default:

--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -750,6 +750,15 @@ int saveinpfile(Project *pr, const char *fname)
         fprintf(f, "\n REQUIRED PRESSURE   %-.4f", hyd->Preq * pr->Ucf[PRESSURE]);
         fprintf(f, "\n PRESSURE EXPONENT   %-.4f", hyd->Pexp);
     }
+    switch (pr->OpPrec)
+    {
+        case LEGACY:
+            fprintf(f, "\n OPERATOR PRECEDENCE LEGACY");
+            break;
+        case STANDARD:
+            fprintf(f, "\n OPERATOR PRECEDENCE STANDARD");
+            break;
+    }
 
     // Write [REPORT] section
     fprintf(f, "\n\n");

--- a/src/input1.c
+++ b/src/input1.c
@@ -101,6 +101,7 @@ void setdefaults(Project *pr)
     strncpy(parser->DefPatID, DEFPATID, MAXID);
 
     pr->Warnflag = FALSE;       // Warning flag is off
+    pr->OpPrec = LEGACY;        // Operator precedence is legacy
     parser->Unitsflag = US;     // US unit system
     parser->Flowflag = GPM;     // Flow units are gpm
     parser->Pressflag = PSI;    // Pressure units are psi

--- a/src/input3.c
+++ b/src/input3.c
@@ -26,6 +26,7 @@ extern char *MixTxt[];
 extern char *Fldname[];
 extern char *DemandModelTxt[];
 extern char *BackflowTxt[];
+extern char *OpPrecTxt[];
 extern char *CurveTypeTxt[];
 
 // Imported Functions
@@ -1895,6 +1896,7 @@ int optionchoice(Project *pr, int n)
 **    PATTERN             id
 **    DEMAND MODEL        DDA/PDA
 **    BACKFLOW ALLOWED    YES/NO
+**    OPERATOR PRECEDENCE LEGACY/STANDARD
 **--------------------------------------------------------------
 */
 {
@@ -2026,6 +2028,16 @@ int optionchoice(Project *pr, int n)
         choice = findmatch(parser->Tok[2], BackflowTxt);
         if (choice < 0) return setError(parser, 2, 213);
         hyd->EmitBackFlag = choice;
+    }
+
+    // Rule OPERATOR PRECEDENCE
+    else if (match(parser->Tok[0], w_OPERATOR))
+    {
+        if (n < 2) return 0;
+        if (!match(parser->Tok[1], w_PRECEDENCE)) return -1;
+        choice = findmatch(parser->Tok[2], OpPrecTxt);
+        if (choice < 0) return setError(parser, 2, 213);
+        pr->OpPrec = choice;
     }
 
     // Return -1 if keyword did not match any option

--- a/src/project.c
+++ b/src/project.c
@@ -48,6 +48,7 @@ int openproject(Project *pr, const char *inpFile, const char *rptFile,
     pr->outfile.SaveHflag = FALSE;
     pr->outfile.SaveQflag = FALSE;
     pr->Warnflag = FALSE;
+    pr->OpPrec = LEGACY;
     pr->report.Messageflag = TRUE;
     pr->report.Rptflag = 1;
 

--- a/src/text.h
+++ b/src/text.h
@@ -131,6 +131,10 @@
 #define   w_EMITTER     "EMIT"
 #define   w_BACKFLOW    "BACK"
 #define   w_ALLOWED     "ALLOW"
+#define   w_OPERATOR    "OPER"
+#define   w_PRECEDENCE  "PREC"
+#define   w_LEGACY      "LEGA"
+#define   w_STANDARD    "STAND"
 
 #define   w_PRICE       "PRICE"
 #define   w_DMNDCHARGE  "DEMAN"

--- a/src/types.h
+++ b/src/types.h
@@ -315,6 +315,11 @@ typedef enum {
   PDA            // pressure driven analysis
 } DemandModelType;
 
+typedef enum {
+  LEGACY,        // OR goes first, AND goes later
+  STANDARD       // AND goes first, OR goes later
+} OpPrecType;
+
 /*
 ------------------------------------------------------
    Fundamental Data Structures
@@ -907,7 +912,8 @@ typedef struct Project {
 
   int
     Openflag,                    // Project open flag
-    Warnflag;                    // Warning flag
+    Warnflag,                    // Warning flag
+    OpPrec;                      // Operator precedence flag
 
   char
     Msg[MAXMSG+1],               // General-purpose string: errors, messages


### PR DESCRIPTION
Implements https://github.com/OpenWaterAnalytics/EPANET/issues/844. Due to the lack of response to the question raised in the issue, I've temporarily placed this flag in the top-level struct `Project`.

The `evalpremises` function has been refactored, compared to the draft in the issue. Now it uses the same implementation as the one in [Wikipedia](https://en.wikipedia.org/wiki/Short-circuit_evaluation#Precedence). Hopefully this refactoring won't change behaviors with established programs or break compatibility with existing `inp` files.

TODO:
- [ ] Add tests
- [ ] Unify the abbreviation for “rule operator precedence” throughout the code base?
    Currently, 1. `OPERATOR PRECEDENCE` (without `RULES`), 2. `RULE_OP_PREC`, 3. `R_PREC`, 4. `OpPrec` are used.
- [ ] Add the third possible precedence?
    The third type of operator precedence is that, `AND` and `OR` have the same priority. In this case, associativity rules determine the order of evaluation, so the whole premise simply evaluated from left to right. Would anyone really want to use it?