### PR TITLE
Decoupled pressure units from the flow unit system

### DIFF
--- a/ReleaseNotes2_3.md
+++ b/ReleaseNotes2_3.md
@@ -42,6 +42,8 @@ This document describes the changes and updates that have been made in version 2
 
  - `EN_PRESS_UNITS` can now be used with `EN_getoption` and `EN_setoption` to get or set the pressure unit used in EPANET.
 
+ - Decoupled pressure units from the flow unit system, allowing them to be set independently to support mixed-unit conventions (e.g., using LPS for flow and PSI for pressure).
+
  - The following constants can be used with EN_getnodevalue to retrieve the components of a node's total demand at a given point in time:
    - `EN_FULLDEMAND` - the consumer demand requested
    - `EN_DEMANDFLOW` - the consumer demand delivered

--- a/include/epanet2.bas
+++ b/include/epanet2.bas
@@ -166,6 +166,8 @@ Public Const EN_CMS = 10
 Public Const EN_PSI = 0           ' Pressure units types
 Public Const EN_KPA = 1
 Public Const EN_METERS = 2
+Public Const EN_BAR = 3
+Public Const EN_FEET = 4
 
 Public Const EN_DDA = 0           ' Demand driven analysis
 Public Const EN_PDA = 1           ' Pressure driven analysis

--- a/include/epanet2.cs
+++ b/include/epanet2.cs
@@ -170,6 +170,8 @@ namespace EpanetCSharpLibrary
         public const int EN_PSI = 0;           //Pressure units types
         public const int EN_KPA = 1;
         public const int EN_METERS = 2;
+        public const int EN_BAR = 3;
+        public const int EN_FEET = 4;
 
         public const int EN_DDA = 0;           //Demand driven analysis
         public const int EN_PDA = 1;           //Pressure driven analysis

--- a/include/epanet2.pas
+++ b/include/epanet2.pas
@@ -174,6 +174,8 @@ const
  EN_PSI        = 0;   { Pressure units types }
  EN_KPA        = 1;
  EN_METERS     = 2;
+ EN_BAR        = 3;
+ EN_FEET       = 4;
 
  EN_DDA        = 0;   { Demand model types }
  EN_PDA        = 1;  

--- a/include/epanet2.vb
+++ b/include/epanet2.vb
@@ -161,6 +161,8 @@ Public Const EN_CMS = 10
 Public Const EN_PSI = 0           ' Pressure units types
 Public Const EN_KPA = 1
 Public Const EN_METERS = 2
+Public Const EN_BAR = 3
+Public Const EN_FEET = 4
 
 Public Const EN_DDA = 0           ' Demand driven analysis
 Public Const EN_PDA = 1           ' Pressure driven analysis

--- a/include/epanet2_enums.h
+++ b/include/epanet2_enums.h
@@ -301,14 +301,14 @@ typedef enum {
 /// Pressure units
 /**
 The available choices for pressure units for the `EN_PRESS_UNITS` option in @ref EN_getoption
-and @ref EN_setoption. For networks using US Customary units for flow (`EN_CFS` through
-`EN_AFD`) pressure units can only be set as PSI. For network using metric units, you can
-select either `EN_METERS` or `EN_KPA`.
+and @ref EN_setoption. 
 */
 typedef enum {
   EN_PSI          = 0,  //!< Pounds per square inch
   EN_KPA          = 1,  //!< Kilopascals
-  EN_METERS       = 2   //!< Meters
+  EN_METERS       = 2,   //!< Meters
+  EN_BAR          = 3,   //!< Bar
+  EN_FEET         = 4    //!< Feet
 } EN_PressUnits;
 
 /// Demand models

--- a/src/enumstxt.h
+++ b/src/enumstxt.h
@@ -76,7 +76,9 @@ char *FlowUnitsTxt[]    = {w_CFS,
 
 char *PressUnitsTxt[]   = {w_PSI,
                            w_KPA,
-                           w_METERS};
+                           w_METERS,
+                           w_BAR,
+                           w_FEET};
 
 char *DemandModelTxt[] = { w_DDA,
                            w_PDA,

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1355,7 +1355,12 @@ int DLLEXPORT EN_setoption(EN_Project p, int option, double value)
 
     case EN_SP_GRAVITY:
         if (value <= 0.0) return 213;
-        Ucf[PRESSURE] *= (value / hyd->SpGrav);
+        if (p->parser.Pressflag == PSI || 
+            p->parser.Pressflag == KPA || 
+            p->parser.Pressflag == BAR)
+        {
+            Ucf[PRESSURE] *= (value / hyd->SpGrav);
+        }
         hyd->SpGrav = value;
         break;
 
@@ -2285,7 +2290,7 @@ int DLLEXPORT EN_getnodevalue(EN_Project p, int index, int property, double *val
         v = 0.0;
         if (Node[index].Ke > 0.0)
         {
-            ecfTmp = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT * hyd->SpGrav);
+            ecfTmp = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : MperFT;
             v = Ucf[FLOW] / pow((ecfTmp * Node[index].Ke), (1.0 / hyd->Qexp));
         }
         break;
@@ -2533,7 +2538,7 @@ int DLLEXPORT EN_setnodevalue(EN_Project p, int index, int property, double valu
         if (value < 0.0) return 209;
         if (value > 0.0)
         {
-            ecfTmp = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT * hyd->SpGrav);
+            ecfTmp = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : MperFT;
             value = pow((Ucf[FLOW] / value), hyd->Qexp) / ecfTmp;
         }
         Node[index].Ke = value;

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -2285,8 +2285,7 @@ int DLLEXPORT EN_getnodevalue(EN_Project p, int index, int property, double *val
         v = 0.0;
         if (Node[index].Ke > 0.0)
         {
-            ecfTmp = (parser->Unitsflag == US) ? (1.0 / PSIperFT) : (1.0 / MperFT);
-            ecfTmp /= hyd->SpGrav;
+            ecfTmp = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT * hyd->SpGrav);
             v = Ucf[FLOW] / pow((ecfTmp * Node[index].Ke), (1.0 / hyd->Qexp));
         }
         break;
@@ -2534,8 +2533,7 @@ int DLLEXPORT EN_setnodevalue(EN_Project p, int index, int property, double valu
         if (value < 0.0) return 209;
         if (value > 0.0)
         {
-            ecfTmp = (parser->Unitsflag == US) ? (1.0 / PSIperFT) : (1.0 / MperFT);
-            ecfTmp /= hyd->SpGrav;
+            ecfTmp = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT * hyd->SpGrav);
             value = pow((Ucf[FLOW] / value), hyd->Qexp) / ecfTmp;
         }
         Node[index].Ke = value;

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1411,8 +1411,6 @@ int DLLEXPORT EN_setoption(EN_Project p, int option, double value)
     case EN_PRESS_UNITS:
         unit = ROUND(value);
         if (unit < 0 || unit > METERS) return 205;
-        if (p->parser.Unitsflag == US && unit > PSI) return 0;
-        if (p->parser.Unitsflag == SI && unit == PSI) return 0;
         p->parser.Pressflag = unit;
 
         dfactor = Ucf[DEMAND];

--- a/src/input1.c
+++ b/src/input1.c
@@ -453,10 +453,10 @@ void initunits(Project *pr)
 
     strcpy(rpt->Field[PRESSURE].Units, PressUnitsTxt[parser->Pressflag]);
     pcf = PSIperFT * hyd->SpGrav; // Default to PSI
-    if (parser->Pressflag == METERS) pcf = MperFT * hyd->SpGrav;
+    if (parser->Pressflag == METERS) pcf = MperFT;
     if (parser->Pressflag == KPA)    pcf = KPAperPSI * PSIperFT * hyd->SpGrav;
     if (parser->Pressflag == BAR)    pcf = BARperPSI * PSIperFT * hyd->SpGrav;
-    if (parser->Pressflag == FEET)   pcf = 1.0 * hyd->SpGrav;
+    if (parser->Pressflag == FEET)   pcf = 1.0;
 
     strcpy(rpt->Field[QUALITY].Units, "");
     ccf = 1.0;

--- a/src/input1.c
+++ b/src/input1.c
@@ -545,8 +545,7 @@ void convertunits(Project *pr)
     hyd->Preq /= pr->Ucf[PRESSURE];
 
     // Convert emitter discharge coeffs. to head loss coeff.
-    ecf = (parser->Unitsflag == US) ? (1.0 / PSIperFT) : (1.0 / MperFT);
-    ecf /= hyd->SpGrav;
+    ecf = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT * hyd->SpGrav);
 
     ucf = pow(pr->Ucf[FLOW], hyd->Qexp) / ecf;
     for (i = 1; i <= net->Njuncs; i++)

--- a/src/input1.c
+++ b/src/input1.c
@@ -545,7 +545,7 @@ void convertunits(Project *pr)
     hyd->Preq /= pr->Ucf[PRESSURE];
 
     // Convert emitter discharge coeffs. to head loss coeff.
-    ecf = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT * hyd->SpGrav);
+    ecf = (parser->Unitsflag == US) ? (PSIperFT * hyd->SpGrav) : (MperFT);
 
     ucf = pow(pr->Ucf[FLOW], hyd->Qexp) / ecf;
     for (i = 1; i <= net->Njuncs; i++)

--- a/src/input3.c
+++ b/src/input3.c
@@ -1926,6 +1926,8 @@ int optionchoice(Project *pr, int n)
         else if (match(parser->Tok[1], w_PSI))    parser->Pressflag = PSI;
         else if (match(parser->Tok[1], w_KPA))    parser->Pressflag = KPA;
         else if (match(parser->Tok[1], w_METERS)) parser->Pressflag = METERS;
+        else if (match(parser->Tok[1], w_BAR))    parser->Pressflag = BAR;
+        else if (match(parser->Tok[1], w_FEET))   parser->Pressflag = FEET;
         else return setError(parser, 1, 213);
     }
 

--- a/src/text.h
+++ b/src/text.h
@@ -90,6 +90,8 @@
 #define   w_PSI         "PSI"
 #define   w_KPA         "KPA"
 #define   w_METERS      "METERS"
+#define   w_BAR         "BAR"
+#define   w_FEET        "FEET"
 
 #define   w_ELEV        "ELEV"
 #define   w_DEMAND      "DEMAND"

--- a/src/types.h
+++ b/src/types.h
@@ -238,7 +238,8 @@ typedef enum {
 typedef enum {
   PSI,           // pounds per square inch
   KPA,           // kiloPascals
-  METERS         // meters
+  METERS,        // meters
+  UNITDEFAULT    // default based on unit system (SI or US)
 } PressureUnitsType;
 
 typedef enum {

--- a/src/types.h
+++ b/src/types.h
@@ -83,6 +83,7 @@ typedef  int          INT4;
 #define   MperFT      0.3048
 #define   PSIperFT    0.4333
 #define   KPAperPSI   6.895
+#define   BARperPSI   0.068948
 #define   KWperHP     0.7457
 #define   SECperDAY   86400
 
@@ -239,7 +240,9 @@ typedef enum {
   PSI,           // pounds per square inch
   KPA,           // kiloPascals
   METERS,        // meters
-  UNITDEFAULT    // default based on unit system (SI or US)
+  BAR,           // bar
+  FEET,          // feet
+  DEFAULTUNIT    // default based on unit system (SI or US)
 } PressureUnitsType;
 
 typedef enum {

--- a/tests/test_units.cpp
+++ b/tests/test_units.cpp
@@ -74,13 +74,13 @@ BOOST_FIXTURE_TEST_CASE(test_pressure_units, FixtureInitClose)
     BOOST_REQUIRE(error == 0);
     BOOST_CHECK(units == EN_PSI);
 
-    // Change to pressure from PSI to meters and check it's still PSI
+    // Change to pressure from PSI to meters and check it is meters
     error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
     BOOST_REQUIRE(error == 0);
 
     error = EN_getoption(ph, EN_PRESS_UNITS, &units);
     BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(units == EN_PSI);
+    BOOST_CHECK(units == EN_METERS);
 
     // Change flow units to LPS to change to metric units and rerun simulation
     error = EN_setflowunits(ph, EN_LPS);
@@ -108,12 +108,12 @@ BOOST_FIXTURE_TEST_CASE(test_pressure_units, FixtureInitClose)
     BOOST_REQUIRE(error == 0);
     BOOST_CHECK(abs(p - 298.76035) < 1.e-5);
 
-    // Set pressure to PSI and check that it remains in kPa
+    // Set pressure to PSI and check that it has changed to PSI
     error = EN_setoption(ph, EN_PRESS_UNITS, EN_PSI);
     BOOST_REQUIRE(error == 0);
     error = EN_getoption(ph, EN_PRESS_UNITS, &units);
     BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(units == EN_KPA);
+    BOOST_CHECK(units == EN_PSI);
 
     error = EN_closeH(ph);
     BOOST_REQUIRE(error == 0);
@@ -263,5 +263,198 @@ BOOST_FIXTURE_TEST_CASE(test_rule_unit_change,  FixtureOpenClose)
 
 
 }
+
+BOOST_FIXTURE_TEST_CASE(test_decoupled_pressure_units, FixtureInitClose)
+{
+    int index;
+    long t;
+    double p, units;
+
+    // Create basic network
+    error = EN_addnode(ph, "R1", EN_RESERVOIR, &index);
+    BOOST_REQUIRE(error == 0);
+    error = EN_setnodevalue(ph, index, EN_ELEVATION, 100);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, "J1", EN_JUNCTION, &index);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addlink(ph, "P1", EN_PIPE, "R1", "J1", &index);
+    BOOST_REQUIRE(error == 0);
+
+    // Test 1: Start with US flow units (GPM) and change to PSI
+    error = EN_setflowunits(ph, EN_GPM);
+    BOOST_REQUIRE(error == 0);
+
+    // Should succeed in setting PSI pressure units
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_PSI);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getoption(ph, EN_PRESS_UNITS, &units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(units == EN_PSI);
+
+    // Test 2: With US flow units, set pressure to meters (should now work)
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getoption(ph, EN_PRESS_UNITS, &units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(units == EN_METERS);
+
+    // Test 3: With US flow units, set pressure to kPa (should now work)
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_KPA);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getoption(ph, EN_PRESS_UNITS, &units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(units == EN_KPA);
+
+    // Test 4: Change to SI flow units (LPS) but keep kPa pressure
+    error = EN_setflowunits(ph, EN_LPS);
+    BOOST_REQUIRE(error == 0);
+
+    // Pressure units should remain kPa (not auto-changed to meters)
+    error = EN_getoption(ph, EN_PRESS_UNITS, &units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(units == EN_KPA);
+
+    // Test 5: With SI flow units, set pressure to PSI (should now work)
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_PSI);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getoption(ph, EN_PRESS_UNITS, &units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(units == EN_PSI);
+
+    // Test 6: Run simulation and check pressure values are correctly converted
+    error = EN_openH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_initH(ph, EN_NOSAVE);
+    BOOST_REQUIRE(error == 0);
+    error = EN_runH(ph, &t);
+    BOOST_REQUIRE(error == 0);
+
+    // Get pressure in PSI (should be ~43.33 PSI for 100 ft head)
+    error = EN_getnodevalue(ph, 1, EN_PRESSURE, &p);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(abs(p - 43.33) < 1.e-5);
+
+    // Change pressure units to meters during simulation
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
+    BOOST_REQUIRE(error == 0);
+
+    // Pressure should now be in meters (~30.48 m for 100 ft head)
+    error = EN_getnodevalue(ph, 1, EN_PRESSURE, &p);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(abs(p - 30.48) < 1.e-5);
+
+    error = EN_closeH(ph);
+    BOOST_REQUIRE(error == 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_automatic_pressure_unit_switching, FixtureInitClose)
+{
+    int index;
+    double pressure_units;
+
+    // Create basic network
+    error = EN_addnode(ph, "R1", EN_RESERVOIR, &index);
+    BOOST_REQUIRE(error == 0);
+    error = EN_setnodevalue(ph, index, EN_ELEVATION, 100);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addnode(ph, "J1", EN_JUNCTION, &index);
+    BOOST_REQUIRE(error == 0);
+    error = EN_addlink(ph, "P1", EN_PIPE, "R1", "J1", &index);
+    BOOST_REQUIRE(error == 0);
+
+    // Test 1: Start with US flow units (CFS) - should have PSI pressure units
+    error = EN_setflowunits(ph, EN_CFS);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_PSI);
+
+    // Test 2: Change from US flow units (CFS) to metric flow units (LPS)
+    // Pressure units should automatically change from PSI to METERS
+    error = EN_setflowunits(ph, EN_LPS);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_METERS);
+
+    // Test 3: Change from metric flow units (LPS) back to US flow units (GPM)
+    // Pressure units should automatically change from METERS to PSI
+    error = EN_setflowunits(ph, EN_GPM);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_PSI);
+
+    // Test 4: Change from US flow units (GPM) to another metric flow unit (MLD)
+    // Pressure units should automatically change from PSI to METERS
+    error = EN_setflowunits(ph, EN_MLD);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_METERS);
+
+    // Test 5: Manually set pressure units to kPa while using metric flow units
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_KPA);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_KPA);
+
+    // Test 6: Change from metric flow units (MLD) to US flow units (MGD)
+    // Pressure units should automatically change from kPa to PSI
+    error = EN_setflowunits(ph, EN_MGD);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_PSI);
+
+    // Test 7: Change from US flow units (MGD) to metric flow units (CMH)
+    // Pressure units should automatically change from PSI to METERS
+    error = EN_setflowunits(ph, EN_CMH);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_METERS);
+
+    // Test 8: Set pressure to kPa again with metric flow units
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_KPA);
+    BOOST_REQUIRE(error == 0);
+
+    // Test 9: Change between metric flow units (CMH to CMD)
+    // Pressure units should remain kPa (not changed to METERS since not switching from PSI)
+    error = EN_setflowunits(ph, EN_CMD);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_KPA);
+
+    // Test 10: Change from metric flow units (CMD) to US flow units (AFD)
+    // Pressure units should automatically change from kPa to PSI
+    error = EN_setflowunits(ph, EN_AFD);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_PSI);
+
+    // Test 11: Change between US flow units (AFD to IMGD)
+    // Pressure units should remain PSI
+    error = EN_setflowunits(ph, EN_IMGD);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_PSI);
+
+    // Test 12: Final test - metric flow units (CMS) should change PSI to METERS
+    error = EN_setflowunits(ph, EN_CMS);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(pressure_units == EN_METERS);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_units.cpp
+++ b/tests/test_units.cpp
@@ -312,10 +312,10 @@ BOOST_FIXTURE_TEST_CASE(test_decoupled_pressure_units, FixtureInitClose)
     error = EN_setflowunits(ph, EN_LPS);
     BOOST_REQUIRE(error == 0);
 
-    // Pressure units should remain kPa (not auto-changed to meters)
+    // Pressure units should change to metric default of meters
     error = EN_getoption(ph, EN_PRESS_UNITS, &units);
     BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(units == EN_KPA);
+    BOOST_CHECK(units == EN_METERS);
 
     // Test 5: With SI flow units, set pressure to PSI (should now work)
     error = EN_setoption(ph, EN_PRESS_UNITS, EN_PSI);


### PR DESCRIPTION
This PR decoupled pressure units from the flow unit system, allowing them to be set independently to support mixed-unit conventions (e.g., using LPS for flow and PSI for pressure).

In Canada infrastructure is built using the metric system however many operators and utilities still refer to pressure in PSI.

This update would allow pressure units to be mix either when `PRESSURE` in the `[OPTIONS]` section of the INP is defined, or if the user uses `EN_getoption` and `EN_PRESS_UNITS`.

To keep backwards compatibility the use of `EN_setflowunits` also changes the pressure units to either `METERS` or `PSI` to match the flow unit type.