### PR TITLE
Fixes Bug in EN_setlinkvalue

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4132,10 +4132,9 @@ int DLLEXPORT EN_setlinkvalue(EN_Project p, int index, int property, double valu
         if (Link[index].Type == CVPIPE) return 207;
         s = (char)ROUND(value);
         if (s < 0 || s > 2) return 211;
-        s = s + CLOSED;
         if (property == EN_INITSTATUS)
         {
-            Link[index].InitStatus = s;
+            Link[index].InitStatus = s + CLOSED;
         }
         else
         {


### PR DESCRIPTION
Since version 2.3 the InitStatus of the Pump is set directly, requiring the addition of the enum value of "CLOSED". However, this led to a bug, where the pump status could otherwise not be set anymore, as it was out of range for the if-conditions within setlinkstatus.
I applied the simplest fix, which is to add the CLOSED value only for the init status.