### PR TITLE
Update EN_setlinkvalue for EN_INITSTATUS

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -4130,10 +4130,16 @@ int DLLEXPORT EN_setlinkvalue(EN_Project p, int index, int property, double valu
     case EN_STATUS:
         // Cannot set status for a check valve
         if (Link[index].Type == CVPIPE) return 207;
+        
+        // Status 's' must be either EN_CLOSED (0) or EN_OPEN (1)
+        // (to set the status of a valve to ACTIVE, assign a value to its
+        // EN_INITSETTING or EN_SETTING property)
         s = (char)ROUND(value);
-        if (s < 0 || s > 2) return 211;
+        if (s < 0 || s > 1) return 211;
+
         if (property == EN_INITSTATUS)
         {
+            // Convert 0/1 to StatusType CLOSED/OPEN
             Link[index].InitStatus = s + CLOSED;
         }
         else


### PR DESCRIPTION
This change recognizes that when setting the initial status of a link (`EN_INITSTATUS`) using the toolkit function `EN_setlinkvalue`, the only valid values for it are 0 (`EN_CLOSED`) and 1 (`EN_OPEN`). The previous code also allowed a value of 2 for `ACTIVE`, but that should only apply to valve links and there is no` EN_ACTIVE` constant defined in the toolkit. A comment has been added to the code noting that to make the initial status of a valve `ACTIVE` one should assign a value to the valve's `EN_INITSETTING` property.  