### PR TITLE
Bugfix: Set correct type of curves to ensure a correct conversion of units in pump, valve, and tank curves

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 01/28/2026
+ Last Updated: 02/17/2026
  ******************************************************************************
 */
 
@@ -1476,6 +1476,9 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
     double *Ucf = p->Ucf;
 
     if (!p->Openflag) return 102;
+
+    // Make sure all curve types are correctly set
+    assigncurvetypes(net);
 
     // Determine unit system based on flow units
     qfactor = Ucf[FLOW];

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1470,15 +1470,12 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
 {
     Network *net = &p->network;
 
-    int i, j, oldUnitFlag;
+    int i, j;
     double qfactor, vfactor, hfactor, efactor, pfactor, dfactor, xfactor, yfactor;
     double dcf, pcf, hcf, qcf;
     double *Ucf = p->Ucf;
 
     if (!p->Openflag) return 102;
-
-    // Make sure all curve types are correctly set
-    assigncurvetypes(net);
 
     // Determine unit system based on flow units
     qfactor = Ucf[FLOW];
@@ -1488,7 +1485,6 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
     pfactor = Ucf[PRESSURE];
     dfactor = Ucf[DEMAND];
 
-    oldUnitFlag = p->parser.Unitsflag;
     p->parser.Flowflag = units;
     switch (units)
     {
@@ -1504,23 +1500,17 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
         p->parser.Unitsflag = US;
         break;
     }
-
-    // Revise pressure units depending on flow units
-    if (oldUnitFlag != p->parser.Unitsflag)
-    {
-        if (p->parser.Unitsflag == US) p->parser.Pressflag = PSI;
-        else p->parser.Pressflag = METERS;
-    }
     initunits(p);
 
-    // Update pressure units in rules
+    // Update units in rules
     dcf =  Ucf[DEMAND] / dfactor;
     pcf =  Ucf[PRESSURE] / pfactor;
     hcf =  Ucf[HEAD] / hfactor;
     qcf =  Ucf[FLOW] / qfactor;
     updateruleunits(p, dcf, pcf, hcf, qcf);
 
-    //update curves
+    //update curves after making sure that all curve types are correctly set
+    assigncurvetypes(net);
     for (i = 1; i <= net->Ncurves; i++)
     {
         switch (net->Curve[i].Type)

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/23/2025
+ Last Updated: 02/17/2025
  ******************************************************************************
 */
 #ifndef FUNCS_H
@@ -40,6 +40,7 @@ int     findvalve(Network *, int);
 int     findpump(Network *, int);
 int     findpattern(Network *, const char *);
 int     findcurve(Network *, const char *);
+void    assigncurvetypes(Network *network);
 
 Pdemand finddemand(Pdemand, int);
 int     adddemand(Snode *, double, int, const char *);

--- a/src/project.c
+++ b/src/project.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/17/2026
+ Last Updated: 04/23/2025
  ******************************************************************************
 */
 
@@ -99,49 +99,7 @@ int openproject(Project *pr, const char *inpFile, const char *rptFile,
     errmsg(pr, errcode);
 
     // Fix curve types
-    Network *net = &pr->network;
-
-    // Pump curves
-    for (int i = 1; i <= net->Npumps; i++)
-    {
-        Spump *pump = &net->Pump[i];
-
-        int j;
-        if ((j = pump->Hcurve) > 0) {
-            net->Curve[j].Type = PUMP_CURVE;
-        }
-        if ((j = pump->Ecurve) > 0) {
-            net->Curve[j].Type = EFFIC_CURVE;
-        }
-    }
-
-    // Tank volume curves
-    for (int i=1; i <= net->Ntanks; i++) {
-        Stank* tank = &net->Tank[i];
-
-        int j;
-        if ((j = tank->Vcurve) > 0) {
-            net->Curve[j].Type = VOLUME_CURVE;
-        }
-    }
-
-    // Valve curves
-    for (int i=1; i <= net->Nvalves; i++) {
-        Svalve* valve = &net->Valve[i];
-        Slink* link = &net->Link[valve->Link];
-
-        int j;
-        if (link->Type == PCV) {
-            if((j = valve->Curve) > 0) {
-                net->Curve[j].Type = VALVE_CURVE;
-            }
-        }
-        else if (link->Type == GPV){
-            if((j = valve->Curve) > 0) {
-                net->Curve[j].Type = HLOSS_CURVE;
-            }
-        }
-    }
+    assigncurvetypes(&pr->network);
 
     return errcode;
 }
@@ -1145,6 +1103,58 @@ int findcurve(Network *network, const char *id)
         if (strcmp(id, network->Curve[i].ID) == 0) return i;
     }
     return 0;
+}
+
+void assigncurvetypes(Network *network)
+/*----------------------------------------------------------------
+**  Input:   none
+**  Output:  none
+**  Returns: none
+**  Purpose: assign correct curve type to all curves
+**----------------------------------------------------------------
+*/
+{
+    // Pump curves
+    for (int i = 1; i <= network->Npumps; i++)
+    {
+        Spump *pump = &network->Pump[i];
+
+        int j;
+        if ((j = pump->Hcurve) > 0) {
+            network->Curve[j].Type = PUMP_CURVE;
+        }
+        if ((j = pump->Ecurve) > 0) {
+            network->Curve[j].Type = EFFIC_CURVE;
+        }
+    }
+
+    // Tank volume curves
+    for (int i=1; i <= network->Ntanks; i++) {
+        Stank* tank = &network->Tank[i];
+
+        int j;
+        if ((j = tank->Vcurve) > 0) {
+            network->Curve[j].Type = VOLUME_CURVE;
+        }
+    }
+
+    // Valve curves
+    for (int i=1; i <= network->Nvalves; i++) {
+        Svalve* valve = &network->Valve[i];
+        Slink* link = &network->Link[valve->Link];
+
+        int j;
+        if (link->Type == PCV) {
+            if((j = valve->Curve) > 0) {
+                network->Curve[j].Type = VALVE_CURVE;
+            }
+        }
+        else if (link->Type == GPV){
+            if((j = valve->Curve) > 0) {
+                network->Curve[j].Type = HLOSS_CURVE;
+            }
+        }
+    }
 }
 
 void adjustpattern(int *pat, int index)

--- a/src/project.c
+++ b/src/project.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 04/23/2025
+ Last Updated: 02/17/2026
  ******************************************************************************
 */
 
@@ -97,6 +97,52 @@ int openproject(Project *pr, const char *inpFile, const char *rptFile,
         pr->Openflag = TRUE;
     }
     errmsg(pr, errcode);
+
+    // Fix curve types
+    Network *net = &pr->network;
+
+    // Pump curves
+    for (int i = 1; i <= net->Npumps; i++)
+    {
+        Spump *pump = &net->Pump[i];
+
+        int j;
+        if ((j = pump->Hcurve) > 0) {
+            net->Curve[j].Type = PUMP_CURVE;
+        }
+        if ((j = pump->Ecurve) > 0) {
+            net->Curve[j].Type = EFFIC_CURVE;
+        }
+    }
+
+    // Tank volume curves
+    for (int i=1; i <= net->Ntanks; i++) {
+        Stank* tank = &net->Tank[i];
+
+        int j;
+        if ((j = tank->Vcurve) > 0) {
+            net->Curve[j].Type = VOLUME_CURVE;
+        }
+    }
+
+    // Valve curves
+    for (int i=1; i <= net->Nvalves; i++) {
+        Svalve* valve = &net->Valve[i];
+        Slink* link = &net->Link[valve->Link];
+
+        int j;
+        if (link->Type == PCV) {
+            if((j = valve->Curve) > 0) {
+                net->Curve[j].Type = VALVE_CURVE;
+            }
+        }
+        else if (link->Type == GPV){
+            if((j = valve->Curve) > 0) {
+                net->Curve[j].Type = HLOSS_CURVE;
+            }
+        }
+    }
+
     return errcode;
 }
 

--- a/src/project.c
+++ b/src/project.c
@@ -98,9 +98,6 @@ int openproject(Project *pr, const char *inpFile, const char *rptFile,
     }
     errmsg(pr, errcode);
 
-    // Fix curve types
-    assigncurvetypes(&pr->network);
-
     return errcode;
 }
 

--- a/tests/test_units.cpp
+++ b/tests/test_units.cpp
@@ -131,11 +131,11 @@ BOOST_FIXTURE_TEST_CASE(test_pda_unit_change,  FixtureOpenClose)
 
     error = EN_setflowunits(ph, EN_LPS);
     BOOST_REQUIRE(error == 0);
+    error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
+    BOOST_REQUIRE(error == 0);
 
     error = EN_getdemandmodel(ph, &type, &pmin, &preq, &pexp);
     BOOST_REQUIRE(error == 0);
-	error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
-	BOOST_REQUIRE(error == 0);
     BOOST_CHECK(abs(pmin - (20/PSIperFT*MperFT)) < 1.e-5); 
     BOOST_CHECK(abs(preq - (100/PSIperFT*MperFT)) < 1.e-5); 
 

--- a/tests/test_units.cpp
+++ b/tests/test_units.cpp
@@ -134,6 +134,8 @@ BOOST_FIXTURE_TEST_CASE(test_pda_unit_change,  FixtureOpenClose)
 
     error = EN_getdemandmodel(ph, &type, &pmin, &preq, &pexp);
     BOOST_REQUIRE(error == 0);
+	error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
+	BOOST_REQUIRE(error == 0);
     BOOST_CHECK(abs(pmin - (20/PSIperFT*MperFT)) < 1.e-5); 
     BOOST_CHECK(abs(preq - (100/PSIperFT*MperFT)) < 1.e-5); 
 
@@ -180,6 +182,8 @@ BOOST_FIXTURE_TEST_CASE(test_rule_unit_change,  FixtureOpenClose)
     // Change flow units to lps and pressure to meters
     error = EN_setflowunits(ph, EN_LPS);
     BOOST_REQUIRE(error == 0);
+	error = EN_setoption(ph, EN_PRESS_UNITS, EN_METERS);
+	BOOST_REQUIRE(error == 0);
 
     error = EN_getoption(ph, EN_PRESS_UNITS, &units);
     BOOST_REQUIRE(error == 0);
@@ -312,10 +316,10 @@ BOOST_FIXTURE_TEST_CASE(test_decoupled_pressure_units, FixtureInitClose)
     error = EN_setflowunits(ph, EN_LPS);
     BOOST_REQUIRE(error == 0);
 
-    // Pressure units should change to metric default of meters
+    // Pressure units should not change
     error = EN_getoption(ph, EN_PRESS_UNITS, &units);
     BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(units == EN_METERS);
+    BOOST_CHECK(units == EN_KPA);  
 
     // Test 5: With SI flow units, set pressure to PSI (should now work)
     error = EN_setoption(ph, EN_PRESS_UNITS, EN_PSI);
@@ -349,111 +353,6 @@ BOOST_FIXTURE_TEST_CASE(test_decoupled_pressure_units, FixtureInitClose)
 
     error = EN_closeH(ph);
     BOOST_REQUIRE(error == 0);
-}
-
-BOOST_FIXTURE_TEST_CASE(test_automatic_pressure_unit_switching, FixtureInitClose)
-{
-    int index;
-    double pressure_units;
-
-    // Create basic network
-    error = EN_addnode(ph, "R1", EN_RESERVOIR, &index);
-    BOOST_REQUIRE(error == 0);
-    error = EN_setnodevalue(ph, index, EN_ELEVATION, 100);
-    BOOST_REQUIRE(error == 0);
-    error = EN_addnode(ph, "J1", EN_JUNCTION, &index);
-    BOOST_REQUIRE(error == 0);
-    error = EN_addlink(ph, "P1", EN_PIPE, "R1", "J1", &index);
-    BOOST_REQUIRE(error == 0);
-
-    // Test 1: Start with US flow units (CFS) - should have PSI pressure units
-    error = EN_setflowunits(ph, EN_CFS);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_PSI);
-
-    // Test 2: Change from US flow units (CFS) to metric flow units (LPS)
-    // Pressure units should automatically change from PSI to METERS
-    error = EN_setflowunits(ph, EN_LPS);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_METERS);
-
-    // Test 3: Change from metric flow units (LPS) back to US flow units (GPM)
-    // Pressure units should automatically change from METERS to PSI
-    error = EN_setflowunits(ph, EN_GPM);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_PSI);
-
-    // Test 4: Change from US flow units (GPM) to another metric flow unit (MLD)
-    // Pressure units should automatically change from PSI to METERS
-    error = EN_setflowunits(ph, EN_MLD);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_METERS);
-
-    // Test 5: Manually set pressure units to kPa while using metric flow units
-    error = EN_setoption(ph, EN_PRESS_UNITS, EN_KPA);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_KPA);
-
-    // Test 6: Change from metric flow units (MLD) to US flow units (MGD)
-    // Pressure units should automatically change from kPa to PSI
-    error = EN_setflowunits(ph, EN_MGD);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_PSI);
-
-    // Test 7: Change from US flow units (MGD) to metric flow units (CMH)
-    // Pressure units should automatically change from PSI to METERS
-    error = EN_setflowunits(ph, EN_CMH);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_METERS);
-
-    // Test 8: Set pressure to kPa again with metric flow units
-    error = EN_setoption(ph, EN_PRESS_UNITS, EN_KPA);
-    BOOST_REQUIRE(error == 0);
-
-    // Test 9: Change between metric flow units (CMH to CMD)
-    // Pressure units should remain kPa (not changed to METERS since not switching from PSI)
-    error = EN_setflowunits(ph, EN_CMD);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_KPA);
-
-    // Test 10: Change from metric flow units (CMD) to US flow units (AFD)
-    // Pressure units should automatically change from kPa to PSI
-    error = EN_setflowunits(ph, EN_AFD);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_PSI);
-
-    // Test 11: Change between US flow units (AFD to IMGD)
-    // Pressure units should remain PSI
-    error = EN_setflowunits(ph, EN_IMGD);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_PSI);
-
-    // Test 12: Final test - metric flow units (CMS) should change PSI to METERS
-    error = EN_setflowunits(ph, EN_CMS);
-    BOOST_REQUIRE(error == 0);
-    error = EN_getoption(ph, EN_PRESS_UNITS, &pressure_units);
-    BOOST_REQUIRE(error == 0);
-    BOOST_CHECK(pressure_units == EN_METERS);
 }
 
 


### PR DESCRIPTION
# Bugfix: Incorrect conversion of units in pump, valve, and tank curves

## Current observed behavior

How to reproduce and trigger the bug:
1. Having loaded a network with imperial flow units (e.g., Net1)
2. Changing the flow units to metric units by calling `setflowunits`
3. Saving the network as a new .inp file by calling `saveinpfile`

The values of pump curves, head loss curves, tank volume curves, etc. have not been converted,
and therefore *running a hydraulic analysis on this new .inp file gives wrong results.*

## Desired behavior

The values of pump curves, head loss curves, and tank volume curves should have been converted as well to guarantee correct results when running a hydraulic analysis.

## Analysis and proposed fix

When parsing an .inp file, all curve types are set to GENERIC, no matter if they are, for instance, used a pump curve. As a consequence, their values are not converted when the flow units are changed.

### Proposed fix

I propose the following fix:

`After the .inp has been parsed: Iterate over all pumps, tanks, and valves, check for curves and set/correct their type.`

Let me know if you find this a reasonable fix or if you would suggest a different fix.
Should you approve this PR, I would appreciate it if you could create a new (minor) release of EPANET asap.
 
Thanks!
