### PR TITLE
Docs update: Rename EMITTER BACKFLOW to BACKFLOW ALLOWED

### DIFF
--- a/doc/toolkit-input.dox
+++ b/doc/toolkit-input.dox
@@ -321,7 +321,7 @@ __Formats:__
 <tr><td><B>PATTERN</B></td><td><I>id</I></td></tr>
 <tr><td><B>DEMAND MULTIPLIER</B></td><td><I>value</I></td></tr>
 <tr><td><B>EMITTER EXPONENT</B></td><td><I>value</I></td></tr>
-<tr><td><B>EMITTER BACKFLOW</B></td><td><B>YES / NO</B></td></tr>
+<tr><td><B>BACKFLOW ALLOWED</B></td><td><B>YES / NO</B></td></tr>
 <tr><td><B>QUALITY</B></td><td><B>NONE / CHEMICAL / AGE / TRACE&nbsp;&nbsp; </B><I>nodeID</I></td></tr>
 <tr><td><B>DIFFUSIVITY</B></td><td><I>value</I></td></tr>
 <tr><td><B>TOLERANCE</B></td><td><I>value</I></td></tr>
@@ -384,7 +384,7 @@ The <b>DEMAND MULTIPLIER</b> is used to adjust the values of baseline demands fo
 
 <b>EMITTER EXPONENT</b> specifies the power to which the pressure at a junction is raised when computing the flow issuing from an emitter. The default is 0.5.
 
-<b>EMITTER BACKFLOW</b> specifies if back flow through an emitter (i.e., flow into the network) is allowed. The default is <b>YES</b>.
+<b>BACKFLOW ALLOWED</b> specifies if back flow through an emitter (i.e., flow into the network) is allowed. The default is <b>YES</b>.
 
 \b QUALITY selects the type of water quality analysis to perform. The choices are <b>NONE, CHEMICAL, AGE</b>, and \b TRACE. In place of \b CHEMICAL the actual name of the chemical can be used followed by its concentration units (e.g., <b>CHLORINE mg/L</b>). If \b TRACE is selected it must be followed by the ID label of the node being traced. The default selection is \b NONE (no water quality analysis).
 


### PR DESCRIPTION
The documentation still has the previous keyword, for reference it was changed here:
https://github.com/OpenWaterAnalytics/EPANET/issues/780