### PR TITLE
modifies cmake install statements to be standard system locations. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,18 @@ ENDIF(MSVC AND "${CMAKE_VS_PLATFORM_NAME}" MATCHES "(Win32)")
 
 target_include_directories(epanet2 PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-install(TARGETS epanet2 DESTINATION .)
-install(TARGETS runepanet DESTINATION .)
-install(FILES ./include/epanet2.h DESTINATION .)
-install(FILES ./include/epanet2_2.h DESTINATION .)
-install(FILES ./include/epanet2_enums.h DESTINATION .)
+# Install the library to 'lib'
+install(TARGETS epanet2
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+# Install the executable to 'bin'
+install(TARGETS runepanet DESTINATION bin)
+
+# Install the headers to 'include'
+install(FILES
+    include/epanet2.h
+    include/epanet2_2.h
+    include/epanet2_enums.h
+    DESTINATION include)

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 
 class EpanetConan(ConanFile):
     name = "epanet"
-    version = "2.2"
+    version = "2.3.5"
     description = "EPANET is an industry-standard program for modeling the hydraulic and water quality behavior of water distribution system pipe networks."
     homepage = "https://github.com/OpenWaterAnalytics/EPANET"
     url = "https://github.com/OpenWaterAnalytics/EPANET"


### PR DESCRIPTION
also updates the version number in conan. I noticed that a conan update was less forgiving of the install location, and this seems to be a more "normal" structure for cmake.