### PR TITLE
Add build flag to enable UBSAN in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@
 # Build Options:
 #   BUILD_TESTS = ON/OFF
 #   BUILD_PY_LIB = ON/OFF
+#   SANITIZERS_ENABLED = ON/OFF
+#    Enables Undefined Behaviour Sanitizer for tests (if supported by toolchain)
 #
 # Generic Invocation:
 #   cmake -E make_directory buildprod

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,18 +6,29 @@
 # Modified by: Michael E. Tryby
 #              US EPA ORD/NRMRL
 #
-
+include(CheckCXXCompilerFlag)
 
 # Sets for output directory for executables and libraries.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 if(UNIX)
-    set(CMAKE_CXX_FLAGS "-std=c++11")
+    set(CMAKE_CXX_FLAGS "-std=c++11 -g")
 endif(UNIX)
+
+# Check for UBSAN support
+set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
+set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=undefined")
+check_cxx_source_compiles("int main() { return 0; }" SANITIZERS_SUPPORTED)
+unset(CMAKE_REQUIRED_FLAGS)
+unset(CMAKE_REQUIRED_LINK_OPTIONS)
 
 
 add_executable(test_net_builder test_net_builder.cpp)
 target_link_libraries(test_net_builder ${Boost_LIBRARIES} epanet2)
+if(SANITIZERS_SUPPORTED AND SANITIZERS_ENABLED)
+    target_compile_options(test_net_builder PUBLIC -fsanitize=undefined)
+    target_link_options(test_net_builder PUBLIC -fsanitize=undefined)
+endif()
 add_test(NAME test_net_builder
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_net_builder
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)
@@ -46,6 +57,10 @@ set(toolkit_test_srcs
 
 add_executable(test_toolkit ${toolkit_test_srcs})
 target_link_libraries(test_toolkit ${Boost_LIBRARIES} epanet2)
+if(SANITIZERS_SUPPORTED AND SANITIZERS_ENABLED)
+    target_compile_options(test_toolkit PUBLIC -fsanitize=undefined)
+    target_link_options(test_toolkit PUBLIC -fsanitize=undefined)
+endif()
 add_test(NAME test_toolkit
     COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_toolkit
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)
@@ -53,6 +68,10 @@ add_test(NAME test_toolkit
 
 
 add_executable(test_reent test_reent.cpp)
+if(SANITIZERS_SUPPORTED AND SANITIZERS_ENABLED)
+    target_compile_options(test_reent PUBLIC -fsanitize=undefined)
+    target_link_options(test_reent PUBLIC -fsanitize=undefined)
+endif()
 
 IF(MSVC)
     target_link_libraries(test_reent ${Boost_LIBRARIES} epanet2)

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -1,3 +1,11 @@
+include(CheckCXXCompilerFlag)
+
+# Check for UBSAN support
+set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
+set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=undefined")
+check_cxx_source_compiles("int main() { return 0; }" SANITIZERS_SUPPORTED)
+unset(CMAKE_REQUIRED_FLAGS)
+unset(CMAKE_REQUIRED_LINK_OPTIONS)
 
 if(UNIX)
     set(CMAKE_CXX_FLAGS "-std=c++11")
@@ -13,16 +21,27 @@ add_executable(test_cstrhelper ./test_cstrhelper.cpp
                                ../../src/util/cstr_helper.c)
 target_include_directories(test_cstrhelper PUBLIC ../../src/)
 target_link_libraries(test_cstrhelper ${Boost_LIBRARIES})
+if(SANITIZERS_SUPPORTED AND SANITIZERS_ENABLED)
+    target_compile_options(test_cstrhelper PUBLIC -fsanitize=undefined)
+    target_link_options(test_cstrhelper PUBLIC -fsanitize=undefined)
+endif()
 
 
 add_executable(test_errormanager ./test_errormanager.cpp
                                  ../../src/util/errormanager.c)
 target_include_directories(test_errormanager PUBLIC ../../src/)
 target_link_libraries(test_errormanager ${Boost_LIBRARIES})
-
+if(SANITIZERS_SUPPORTED AND SANITIZERS_ENABLED)
+    target_compile_options(test_errormanager PUBLIC -fsanitize=undefined)
+    target_link_options(test_errormanager PUBLIC -fsanitize=undefined)
+endif()
 
 add_executable(test_filemanager ./test_filemanager.cpp
                                 ../../src/util/filemanager.c
                                 ../../src/util/cstr_helper.c)
 target_include_directories(test_filemanager PUBLIC ../../src/)
 target_link_libraries(test_filemanager ${Boost_LIBRARIES})
+if(SANITIZERS_SUPPORTED AND SANITIZERS_ENABLED)
+    target_compile_options(test_filemanager PUBLIC -fsanitize=undefined)
+    target_link_options(test_filemanager PUBLIC -fsanitize=undefined)
+endif()


### PR DESCRIPTION
This PR adds a new CMake build flag, `SANITIZERS_ENABLED=ON/OFF`, to enable the [Undefined Behavior Sanitizer (UBSAN)](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) in tests.

UBSAN detects undefined behavior in runtime such as signed integer overflow, integer division by zero, function calls through function pointers with wrong signatures, etc ([full list](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks)).

Undefined behavior can be a cause of hard to detect bugs in C code, with problems compounding when optimizations are enabled. Using UBSAN can help during development, making detecting these issues early.

Only enabled if supported by the toolchain, otherwise ignored.
Tested with Clang 14.0.6, no undefined behaviors errors were detected.
Tested working with G++ 12.2.0.