### PR TITLE
Enforce dot decimal point for INP files

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,16 +2,32 @@
 
 The most straightforward way to build the EPANET files is by using `CMake` ([https://cmake.org/](https://cmake.org/)). `CMake` is a cross-platform build tool that generates platform native build systems that can be used with your compiler of choice. It uses a generator concept to represent different build tooling. `CMake` automatically detects the platform it is running on and generates the appropriate makefiles for the platform default compiler. Different generators can also be specified.
 
-The project's `CMake` file (`CMakeLists.txt`) is located in its root directory and supports builds for Linux, Mac OS and Windows. To build the EPANET library and its command line executable using `CMake`, first open a console window and navigate to the project's root directory. Then enter the following commands:
+The project's `CMake` file (`CMakeLists.txt`) is located in its root directory and supports builds for Linux, Mac OS and Windows. To build the EPANET library and its command line executable using `CMake`, first open a console window and navigate to the project's root directory. Then create a build directory using the following commands:
 
 ```
 mkdir build
 cd build
-cmake ..
+```
+
+Next use the following `CMake` commands depending on your operating system:
+
+Windows:
+```
+cmake .. -A x64  (or -A Win32 for a 32-bit build)
 cmake --build . --config Release
 ```
 
-Note: under Windows, the third command should be `cmake .. -A Win32` for a 32-bit build or `cmake .. -A x64` for a 64-bit build when Microsoft Visual Studio is the default compiler.
+Linux:
+```
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build .
+```
+
+MacOS:
+```
+cmake ..
+cmake --build . --config Release
+```
 
 For Windows the resulting EPANET toolkit library `epanet2.dll` and its command line executable `runepanet.exe` are placed in the `build\bin\Release` directory. The `build\lib\Release` directory will contain an `epanet2.lib` file which is needed to build C/C++ applications using the Windows version of the library. For Linux and Mac OS the EPANET toolkit shared library `libepanet2.so` appears in the `build/lib` directory and the command line executable `runepanet` is in the `build/bin` directory.
 

--- a/ReleaseNotes2_3.md
+++ b/ReleaseNotes2_3.md
@@ -149,4 +149,6 @@ This document describes the changes and updates that have been made in version 2
  - Fixes errors converting the units of the Leak Area and Leak Area Expansion parameters used in the FAVAD pipe leakage model.
  - To avoid reporting that full tanks are overflowing when they see negligible net inflows or outflows, those flows are now ignored when updating the tank's volume and head.
  #### 2.3.5:
- - Makes `EN_setflowunits` change flow units for all assigned data curves but no longer changes pressure units when the unit system changes since v2.3 supports mixed-unit conventions (e.g., using LPS for flow and PSI for pressure). 
+ - Makes `EN_setflowunits` change flow units for all assigned data curves but no longer changes pressure units when the unit system changes since v2.3 supports mixed-unit conventions (e.g., using LPS for flow and PSI for pressure).
+#### 2.3.6:
+- Insures that a dot decimal point is used when reading/writing EPANET files regardless of what the system locale uses.

--- a/doc/toolkit-input.dox
+++ b/doc/toolkit-input.dox
@@ -18,7 +18,7 @@ The file is organized by sections where each section begins with a keyword enclo
     
 The order of sections is not important. However, whenever a node or link is referred to in a section it must have already been defined in the [JUNCTIONS], [RESERVOIRS], [TANKS], [PIPES], [PUMPS], or [VALVES] sections. Thus it is recommended that these sections be placed first.
 
-Each section can contain one or more lines of data. Blank lines can appear anywhere in the file and the semicolon (;) can be used to indicate that what follows on the line is a comment, not data. A maximum of 1024 characters can appear on a line.
+Each section can contain one or more lines of data. Blank lines can appear anywhere in the file and the semicolon (;) can be used to indicate that what follows on the line is a comment, not data. Numerical data must use a dot ('.') as the decimal point. A maximum of 1024 characters can appear on a line.
 
 The ID labels used to identify nodes, links, curves and patterns can be any combination of up to 31 characters and numbers.
 

--- a/include/epanet2_2.h
+++ b/include/epanet2_2.h
@@ -11,7 +11,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 03/05/2026
+ Last Updated: 05/11/2026
  ******************************************************************************
  */
 
@@ -219,6 +219,9 @@ typedef struct Project *EN_Project;
   @param ph an EPANET project handle.
   @param filename the name of the file to create.
   @return an error code
+  
+  This function is not thread safe. Do not call it for multiple projects
+  being analyzed in separate threads simultaneously.
   */
   int DLLEXPORT EN_saveinpfile(EN_Project ph, const char *filename);
 

--- a/src/epanet.c
+++ b/src/epanet.c
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 03/19/2026
+ Last Updated: 05/11/2026
  ******************************************************************************
 */
 
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <float.h>
 #include <math.h>
+#include <locale.h>
 
 #include "epanet2_2.h"
 #include "types.h"
@@ -48,6 +49,10 @@ int DLLEXPORT EN_createproject(EN_Project *p)
     getTmpName(project->TmpOutFname);
     getTmpName(project->TmpStatFname);
     *p = project;
+    
+    // Use system's decimal point (will be changed locally to dot
+    // when reading/writing EPANET input files)
+    setlocale(LC_NUMERIC, "");
     return 0;
 }
 

--- a/src/epanet2.c
+++ b/src/epanet2.c
@@ -7,12 +7,13 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 03/19/2026
+ Last Updated: 05/11/2026
  ******************************************************************************
 */
 
 #include <stdlib.h>
 #include <string.h>
+#include <locale.h>
 
 #include "types.h"
 #include "funcs.h"
@@ -32,6 +33,10 @@ void createtmpfiles()
     getTmpName(_defaultProject->TmpHydFname);
     getTmpName(_defaultProject->TmpOutFname);
     getTmpName(_defaultProject->TmpStatFname);
+    
+    // Use system's decimal point (will be changed locally to dot
+    // when reading/writing EPANET input files)
+    setlocale(LC_NUMERIC, "");
 }
 
 void removetmpfiles()

--- a/src/inpfile.c
+++ b/src/inpfile.c
@@ -7,7 +7,7 @@ Description:  saves network data to an EPANET formatted text file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 04/19/2025
+Last Updated: 05/11/2026
 ******************************************************************************
 */
 
@@ -15,6 +15,7 @@ Last Updated: 04/19/2025
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <locale.h>
 
 #include "types.h"
 #include "funcs.h"
@@ -132,6 +133,9 @@ int saveinpfile(Project *pr, const char *fname)
 
     // Open the new text file
     if ((f = fopen(fname, "wt")) == NULL) return 302;
+    
+    // Set global decimal point character to dot (not thread safe)
+    setlocale(LC_NUMERIC, "C");
 
     // Write [TITLE] section
     fprintf(f, s_TITLE);
@@ -881,5 +885,9 @@ int saveinpfile(Project *pr, const char *fname)
     // Close the new input file
     fprintf(f, "\n%s\n", s_END);
     fclose(f);
+    
+    // Reset global decimal point character to system value
+    setlocale(LC_NUMERIC, "");
+    
     return 0;
 }

--- a/src/input2.c
+++ b/src/input2.c
@@ -7,14 +7,17 @@ Description:  reads and interprets network data from an EPANET input file
 Authors:      see AUTHORS
 Copyright:    see AUTHORS
 License:      see LICENSE
-Last Updated: 02/19/2025
+Last Updated: 05/11/2026
 ******************************************************************************
 */
+
+#define _GNU_SOURCE  // to expose strtod_l on Linux
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <locale.h>
 
 #include "types.h"
 #include "funcs.h"
@@ -676,11 +679,42 @@ int getfloat(char *s, double *y)
 **  Output:  *y = floating point number
 **           returns 1 if conversion successful, 0 if not
 **  Purpose: converts string to floating point number
+**
+**  This function will correctly convert a numerical string
+**  that uses a dot for its decimal point (as required by
+**  EPANET's input file format) no matter what the system
+**  locale uses as the decimal point.
 **-----------------------------------------------------------
 */
 {
+// Windows equivalents for POSIX C terms
+#ifdef _WIN32
+  #define locale_t _locale_t
+  #define LC_NUMERIC_MASK LC_NUMERIC
+  #define newlocale(mask, locale, base) _create_locale(mask, locale)
+  #define freelocale _free_locale
+  #define strtod_l _strtod_l
+#endif
+
     char *endptr;
-    *y = (double)strtod(s, &endptr);
+    locale_t locale;
+    struct lconv *lc = localeconv();
+
+    // Use standard strtod function if system locale uses dot for decimal point
+    if (lc->decimal_point[0] == '.')
+    {
+        *y = strtod(s, &endptr);
+    }
+    
+    // Otherwise create a thread-safe local locale with a dot
+    // decimal point and use it with the strtod_l function
+    else
+    {
+        locale = newlocale(LC_NUMERIC_MASK, "C", NULL);
+        *y = strtod_l(s, &endptr, locale);
+        freelocale(locale);
+    }    
+
     if (*endptr > 0) return 0;
     return 1;
 }

--- a/src/input2.c
+++ b/src/input2.c
@@ -18,6 +18,9 @@ Last Updated: 05/11/2026
 #include <string.h>
 #include <math.h>
 #include <locale.h>
+#ifdef __APPLE__
+  #include <xlocale.h>
+#endif
 
 #include "types.h"
 #include "funcs.h"

--- a/src/types.h
+++ b/src/types.h
@@ -7,7 +7,7 @@
  Authors:      see AUTHORS
  Copyright:    see AUTHORS
  License:      see LICENSE
- Last Updated: 02/03/2026
+ Last Updated: 05/11/2026
  ******************************************************************************
 */
 
@@ -31,7 +31,7 @@ typedef  int          INT4;
    Various constants
 ----------------------------------------------
 */
-#define   CODEVERSION        20305
+#define   CODEVERSION        20306
 #define   MAGICNUMBER        516114521
 #define   ENGINE_VERSION     201   // Used for binary hydraulics file
 #define   EOFMARK            0x1A  // Use 0x04 for UNIX systems


### PR DESCRIPTION
This PR temporarily sets the project decimal point character to a dot when reading or writing EPANET input files, which is the required convention, regardless of what the system locale uses. Numerical output written to EPANET's Report file will use the system locale's setting. See issue #875.

It also modifies the BUILDING.md file to add the `-DCMAKE_BUILD_TYPE=Release` flag to the instructions for a Linux build. See issue #917.