### PR TITLE
fix build issue test_leakage by importing cmath for sqrt

### DIFF
--- a/tests/test_leakage.cpp
+++ b/tests/test_leakage.cpp
@@ -15,6 +15,8 @@
    Tests Pipe Leakage Feature
 */
 
+#include <cmath>
+
 #include <boost/test/unit_test.hpp>
 
 #include "test_toolkit.hpp"


### PR DESCRIPTION
adding in line 18:
```
#include <cmath>
```

to fix
```
EPANET/tests/test_leakage.cpp:103:15: error: ‘sqrt’ was not declared in this scope
103 |     C = 0.6 * sqrt(2. * 32.2);
    |               ^~~~
```

When trying to build the tests:

```
mkdir build
cd build
cmake -DBUILD_TESTS=ON ..
cmake --build . --config Release
cd tests
ctest -C Release --output-on-failure
```