### PR TITLE
raising cmake_minimum_required 3.8.0 -> 3.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 #   CMake is available at https://cmake.org/download/
 #
 
-cmake_minimum_required (VERSION 3.10.0)
+cmake_minimum_required (VERSION 3.16.0)
 
 project(EPANET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 #   CMake is available at https://cmake.org/download/
 #
 
-cmake_minimum_required (VERSION 3.8.0)
+cmake_minimum_required (VERSION 3.10.0)
 
 project(EPANET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 #   CMake is available at https://cmake.org/download/
 #
 
-cmake_minimum_required (VERSION 3.16.0)
+cmake_minimum_required (VERSION 3.10.0)
 
 project(EPANET)
 

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -1,5 +1,5 @@
 # EPANET COMMAND LINE EXECUTABLE
-cmake_minimum_required (VERSION 3.8.0)
+cmake_minimum_required (VERSION 3.10.0)
 
 
 # Sets for output directory for executables and libraries.


### PR DESCRIPTION
Trying to avoid compiler warnings:

CMake Deprecation Warning
(cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
