### PR TITLE
Allow negative bulk and tank reaction orders in EN_setoption

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1285,8 +1285,9 @@ int DLLEXPORT EN_setoption(EN_Project p, int option, double value)
         return 0;
     }
 
-    // All other option values must be non-negative
-    if (value < 0.0) return 213;
+    // Bulk and tank reaction orders can be negative to select
+    // Michaelis-Menten kinetics. All other option values must be non-negative.
+    if (value < 0.0 && option != EN_BULKORDER && option != EN_TANKORDER) return 213;
 
     // Process the specified option
     switch (option)

--- a/tests/test_quality.cpp
+++ b/tests/test_quality.cpp
@@ -97,4 +97,32 @@ BOOST_FIXTURE_TEST_CASE(test_progressive_step, FixtureOpenClose)
 
 }
 
+BOOST_FIXTURE_TEST_CASE(test_michaelis_menten_reaction_orders, FixtureOpenClose)
+{
+    double value = 0.0;
+
+    error = EN_setoption(ph, EN_BULKORDER, -1.0);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_BULKORDER, &value);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(value == -1.0);
+
+    error = EN_setoption(ph, EN_TANKORDER, -1.0);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getoption(ph, EN_TANKORDER, &value);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(value == -1.0);
+
+    // Wall reaction order remains restricted to zero or one.
+    error = EN_setoption(ph, EN_WALLORDER, -1.0);
+    BOOST_CHECK(error == 213);
+
+    error = EN_setoption(ph, EN_CONCENLIMIT, 1.0);
+    BOOST_REQUIRE(error == 0);
+    error = EN_solveH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_solveQ(ph);
+    BOOST_REQUIRE(error == 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
EN_setoption() currently rejects all negative option values before
handling the individual option type. This prevents setting negative
EN_BULKORDER and EN_TANKORDER values through the Toolkit API.

Negative bulk and tank reaction orders are already accepted by the INP
parser and supported by the quality solver as Michaelis-Menten kinetics.

This change allows negative values for EN_BULKORDER and EN_TANKORDER
while preserving the existing validation for other options, including
EN_WALLORDER.

A regression test verifies that negative bulk and tank orders can be set
and retrieved through the Toolkit and used successfully in a quality
analysis.