### PR TITLE
Preserve cylindrical tank volumes in EN_settankdata

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -2878,7 +2878,7 @@ int DLLEXPORT EN_settankdata(EN_Project p, int index, double elev,
 
     int i, j, n, curveIndex = 0;
     double *Ucf = p->Ucf;
-    double area;
+    double area, minVolume;
     Stank *Tank = net->Tank;
     Scurve *curve;
 
@@ -2923,12 +2923,20 @@ int DLLEXPORT EN_settankdata(EN_Project p, int index, double elev,
     Tank[j].Vcurve = curveIndex;
     if (curveIndex == 0)
     {
-        if (minvol > 0.0) Tank[j].Vmin = minvol / Ucf[VOLUME];
-        else Tank[j].Vmin = Tank[j].A * (Tank[j].Hmin - elev / Ucf[ELEV]);
+        // Compute cylindrical volumes in user units before converting them
+        // to internal units, matching the input-file parsing path.
+        minVolume = area * minlvl;
+        if (minvol > 0.0) minVolume = minvol;
+        Tank[j].Vmin = minVolume / Ucf[VOLUME];
+        Tank[j].V0 = (minVolume + area * (initlvl - minlvl)) / Ucf[VOLUME];
+        Tank[j].Vmax = (minVolume + area * (maxlvl - minlvl)) / Ucf[VOLUME];
     }
-    else Tank[j].Vmin = tankvolume(p, j, Tank[j].Hmin);
-    Tank[j].V0 = tankvolume(p, j, Tank[j].H0);
-    Tank[j].Vmax = tankvolume(p, j, Tank[j].Hmax);
+    else
+    {
+        Tank[j].Vmin = tankvolume(p, j, Tank[j].Hmin);
+        Tank[j].V0 = tankvolume(p, j, Tank[j].H0);
+        Tank[j].Vmax = tankvolume(p, j, Tank[j].Hmax);
+    }
     return 0;
 }
 

--- a/tests/data/tank_metric.inp
+++ b/tests/data/tank_metric.inp
@@ -1,0 +1,24 @@
+[TITLE]
+Metric cylindrical tank fidelity test
+
+[JUNCTIONS]
+ J1 100 0
+
+[RESERVOIRS]
+ R1 120
+
+[TANKS]
+ T1 100 5 1 10 5 0
+
+[PIPES]
+ P1 R1 J1 100 100 100 0 Open
+ P2 J1 T1 100 100 100 0 Open
+
+[OPTIONS]
+ Units LPS
+ Headloss H-W
+
+[TIMES]
+ Duration 0
+
+[END]

--- a/tests/test_node.cpp
+++ b/tests/test_node.cpp
@@ -389,3 +389,51 @@ BOOST_AUTO_TEST_CASE(test_reopen_comment, * boost::unit_test::depends_on("node_c
 
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(tankdata_fidelity)
+
+BOOST_AUTO_TEST_CASE(test_settankdata_preserves_cylindrical_tank_volumes)
+{
+    int error = 0;
+    int index = 0;
+    double initialVolumeBefore = 0.0;
+    double minimumVolumeBefore = 0.0;
+    double maximumVolumeBefore = 0.0;
+    double initialVolumeAfter = 0.0;
+    double minimumVolumeAfter = 0.0;
+    double maximumVolumeAfter = 0.0;
+    EN_Project ph = NULL;
+
+    error = EN_createproject(&ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_open(ph, "./tank_metric.inp", DATA_PATH_RPT, "");
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodeindex(ph, (char *)"T1", &index);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getnodevalue(ph, index, EN_INITVOLUME, &initialVolumeBefore);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, index, EN_MINVOLUME, &minimumVolumeBefore);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, index, EN_MAXVOLUME, &maximumVolumeBefore);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_settankdata(ph, index, 100.0, 5.0, 1.0, 10.0, 5.0, 0.0, "");
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getnodevalue(ph, index, EN_INITVOLUME, &initialVolumeAfter);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, index, EN_MINVOLUME, &minimumVolumeAfter);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, index, EN_MAXVOLUME, &maximumVolumeAfter);
+    BOOST_REQUIRE(error == 0);
+
+    BOOST_CHECK_EQUAL(initialVolumeAfter, initialVolumeBefore);
+    BOOST_CHECK_EQUAL(minimumVolumeAfter, minimumVolumeBefore);
+    BOOST_CHECK_EQUAL(maximumVolumeAfter, maximumVolumeBefore);
+
+    EN_close(ph);
+    EN_deleteproject(ph);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
EN_settankdata() currently reconstructs cylindrical tank volumes through
the internal-unit tankvolume() path. This uses a different floating-point
operation order than the INP parser when constructing the same tank.

As a result, reapplying identical tank data through the Toolkit can change
the internally stored tank volumes by a very small amount. In event-driven
hydraulic simulations this can alter the ordering of otherwise simultaneous
tank events and lead to different downstream results.

This change computes cylindrical tank volumes in user units before
converting them to internal units, matching the arithmetic path used by the
INP parser.

A regression test verifies that reapplying identical EN_settankdata()
parameters preserves the initial, minimum, and maximum tank volumes
bit-for-bit.