### PR TITLE
Convert wall reaction parameters in EN_setflowunits

### DIFF
--- a/src/epanet.c
+++ b/src/epanet.c
@@ -1477,7 +1477,7 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
 
     int i, j;
     double qfactor, vfactor, hfactor, efactor, pfactor, dfactor, xfactor, yfactor;
-    double dcf, pcf, hcf, qcf;
+    double dcf, pcf, hcf, qcf, kwallfactor;
     double *Ucf = p->Ucf;
 
     if (!p->Openflag) return 102;
@@ -1506,6 +1506,22 @@ int DLLEXPORT EN_setflowunits(EN_Project p, int units)
         break;
     }
     initunits(p);
+
+    // Preserve the physical meaning of wall reaction coefficients when the
+    // unit system changes. First-order wall coefficients use length/time
+    // units while zero-order coefficients use mass/area/time units.
+    if (p->quality.WallOrder == 0.0)
+        kwallfactor = SQR(efactor / Ucf[ELEV]);
+    else
+        kwallfactor = Ucf[ELEV] / efactor;
+
+    p->quality.Kwall *= kwallfactor;
+    if (p->quality.Rfactor != MISSING) p->quality.Rfactor *= kwallfactor;
+    for (i = 1; i <= net->Nlinks; i++)
+    {
+        if (net->Link[i].Type <= PIPE && net->Link[i].Kw != MISSING)
+            net->Link[i].Kw *= kwallfactor;
+    }
 
     // Update units in rules
     dcf =  Ucf[DEMAND] / dfactor;

--- a/tests/test_units.cpp
+++ b/tests/test_units.cpp
@@ -356,4 +356,96 @@ BOOST_FIXTURE_TEST_CASE(test_decoupled_pressure_units, FixtureInitClose)
 }
 
 
+
+BOOST_FIXTURE_TEST_CASE(test_wall_reaction_unit_change_first_order, FixtureOpenClose)
+{
+    int linkIndex, nodeIndex;
+    double wallOrder, kwallUs, kwallSi, qualityUs, qualitySi;
+
+    error = EN_getoption(ph, EN_WALLORDER, &wallOrder);
+    BOOST_REQUIRE(error == 0);
+    BOOST_REQUIRE(wallOrder == 1.0);
+
+    error = EN_getlinkindex(ph, (char *)"10", &linkIndex);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodeindex(ph, (char *)"21", &nodeIndex);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getlinkvalue(ph, linkIndex, EN_KWALL, &kwallUs);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK_CLOSE(kwallUs, -1.0, 1.e-10);
+
+    error = EN_solveH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_solveQ(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, nodeIndex, EN_QUALITY, &qualityUs);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_setflowunits(ph, EN_LPS);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, linkIndex, EN_KWALL, &kwallSi);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK_CLOSE(kwallSi, kwallUs * MperFT, 1.e-10);
+
+    error = EN_solveH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_solveQ(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, nodeIndex, EN_QUALITY, &qualitySi);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(abs(qualitySi - qualityUs) < 1.e-8);
+
+    error = EN_setflowunits(ph, EN_GPM);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, linkIndex, EN_KWALL, &kwallUs);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK_CLOSE(kwallUs, -1.0, 1.e-10);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_wall_reaction_unit_change_zero_order, FixtureOpenClose)
+{
+    int linkIndex, nodeIndex;
+    double kwallUs, kwallSi, qualityUs, qualitySi;
+
+    error = EN_setoption(ph, EN_WALLORDER, 0.0);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getlinkindex(ph, (char *)"10", &linkIndex);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodeindex(ph, (char *)"21", &nodeIndex);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_getlinkvalue(ph, linkIndex, EN_KWALL, &kwallUs);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK_CLOSE(kwallUs, -1.0, 1.e-10);
+
+    error = EN_solveH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_solveQ(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, nodeIndex, EN_QUALITY, &qualityUs);
+    BOOST_REQUIRE(error == 0);
+
+    error = EN_setflowunits(ph, EN_LPS);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, linkIndex, EN_KWALL, &kwallSi);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK_CLOSE(kwallSi, kwallUs / (MperFT * MperFT), 1.e-10);
+
+    error = EN_solveH(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_solveQ(ph);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getnodevalue(ph, nodeIndex, EN_QUALITY, &qualitySi);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK(abs(qualitySi - qualityUs) < 1.e-8);
+
+    error = EN_setflowunits(ph, EN_GPM);
+    BOOST_REQUIRE(error == 0);
+    error = EN_getlinkvalue(ph, linkIndex, EN_KWALL, &kwallUs);
+    BOOST_REQUIRE(error == 0);
+    BOOST_CHECK_CLOSE(kwallUs, -1.0, 1.e-10);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
EN_setflowunits() updates a project's unit system and already converts
unit-dependent hydraulic data, but wall reaction parameters are currently
left unchanged.

This changes the physical meaning of wall reactions when switching between
US customary and SI flow units. For example, a first-order wall coefficient
of -1 ft/day becomes -1 m/day instead of the equivalent -0.3048 m/day.

This change converts wall reaction parameters whenever the unit system
changes:

- first-order wall coefficients as length/time,
- zero-order wall coefficients as mass/area/time,
- the global wall reaction coefficient,
- per-pipe wall reaction coefficients, and
- the roughness/reaction correlation factor.

Two regression tests cover first-order and zero-order wall reactions. They
verify both the converted coefficient values and preservation of the
resulting water-quality solution across a US-to-SI unit change and back.